### PR TITLE
Set selected item text colour to dark grey

### DIFF
--- a/friends/ChatRoomDlg.res
+++ b/friends/ChatRoomDlg.res
@@ -134,7 +134,7 @@
 			textcolor="darkestGrey"
 			
 			selectedbgcolor="blue"
-			selectedtextcolor="trueWhite"
+			selectedtextcolor="darkestGrey"
 			
 			padding-top=14
 			padding-bottom=5
@@ -342,7 +342,7 @@
 		RichText {
 			textcolor="ChatDialog.HistoryColor"
 			selectedbgcolor="blue"
-			selectedtextcolor="trueWhite"
+			selectedtextcolor="darkestGrey"
 			bgcolor=darkestGrey
 			
 			inset="8 8 8 0"

--- a/friends/ChatRoomDlgFriend.res
+++ b/friends/ChatRoomDlgFriend.res
@@ -105,7 +105,7 @@
 			textcolor="darkestGrey"
 			
 			selectedbgcolor="blue"
-			selectedtextcolor="trueWhite"
+			selectedtextcolor="darkestGrey"
 			
 			padding-top=14
 			padding-bottom=5
@@ -313,7 +313,7 @@
 		RichText {
 			textcolor="ChatDialog.HistoryColor"
 			selectedbgcolor="blue"
-			selectedtextcolor="trueWhite"
+			selectedtextcolor="darkestGrey"
 			bgcolor=darkestGrey
 			
 			inset="8 8 8 0"

--- a/includes/controls.styles
+++ b/includes/controls.styles
@@ -473,7 +473,7 @@
       textcolor  = "Text"
       font-weight=400
       bgcolor  = "none"
-      selectedtextcolor  = "white"
+      selectedtextcolor  = "darkestGrey"
       selectedbgcolor  = "TextSelectedBG"
       shadowtextcolor  = "Text"  // this is the cursor color
 

--- a/includes/friendsandchat.styles
+++ b/includes/friendsandchat.styles
@@ -28,14 +28,14 @@
 	    
 	    friends_chat_text {
 			textcolor="lightestGrey"
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 			SelectedBgColor="blue"
 			font-size=14
 		}
 
 		friends_chat_text_self {
 			textcolor="white" //changed to white to fix ingame not hovering
-			selectedtextcolor="trueWhite" 	
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 			font-size=14
 		}
@@ -44,7 +44,7 @@
 	
 		friends_chat_history {
 			textcolor="ChatDialog.HistoryColor"
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 			font-size=14
 		}
@@ -52,13 +52,13 @@
 		friends_chat_event {
 			textcolor="blue"
 			font-size=14
-			selectedtextcolor="trueWhite"
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 		}
 	
 		friends_chat_bright_event {
 			textcolor="white"
-			selectedtextcolor="trueWhite"
+			selectedtextcolor="darkestGrey"
 			font-size=14
 			font-weight=1000
 		}
@@ -67,13 +67,13 @@
 			textcolor="blue"
 	   		font-style=underline
 			font-size=14
-			selectedtextcolor="trueWhite"
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 		}
 		
 		friends_chat_name_ingame {
 			textcolor="Friends.InGameColor"
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 			font-size=14
 	
@@ -81,20 +81,20 @@
 		
 		friends_chat_self {
 			textcolor="Friends.OnlineColor"
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 			font-size=14
 		}
 		
 		friends_chat_name {
 			textcolor="Friends.OnlineColor"
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 			font-size=14
 		}
 		
 		friends_chat_accountid {
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 			textcolor="grey"
 			font-size=14
@@ -107,7 +107,7 @@
 			font-size=14
 			font-weight=400
 			font-style=none
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 		}
 		

--- a/resource/layout/gamespage_details_news_item.layout
+++ b/resource/layout/gamespage_details_news_item.layout
@@ -47,7 +47,7 @@
 
 		newsitem_body {
 			textcolor="white"
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 			render_bg {}
 			font-size=13
 			font-family=basefont
@@ -70,7 +70,7 @@
 		"newsitem_body bold" {
 			font-weight=1000
 			textcolor="white"
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 		}
 		
 		more_link {

--- a/resource/layout/gamespage_details_welcome.layout
+++ b/resource/layout/gamespage_details_welcome.layout
@@ -41,7 +41,7 @@
 
 		bodycontent {
 			textcolor="white"
-			selectedtextcolor="trueWhite"	
+			selectedtextcolor="darkestGrey"
 			font-size=13
 			render_bg {}
 		}

--- a/resource/layout/musicplayerpanel.layout
+++ b/resource/layout/musicplayerpanel.layout
@@ -72,7 +72,7 @@
 			textcolor="white"
 			bgcolor="none"
 			selectedbgcolor="blue" 
-			selectedtextcolor="truewhite"
+			selectedtextcolor="darkestGrey"
 			render
 			{
 				//line at top
@@ -102,7 +102,7 @@
 			textcolor="white"
 			bgcolor="none"
 			selectedbgcolor="blue" 
-			selectedtextcolor="truewhite"
+			selectedtextcolor="darkestGrey"
 			render
 			{
 				//line at top

--- a/resource/layout/overlaywebbrowser.layout
+++ b/resource/layout/overlaywebbrowser.layout
@@ -360,7 +360,7 @@
 			font-size=14
 			textcolor="grey"
 			bgcolor="none"
-			selectedtextcolor="white"
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 			shadowtextcolor="grey"	// this is the cursor color
 			padding-top=9

--- a/resource/layout/uinavigatorpanel.layout
+++ b/resource/layout/uinavigatorpanel.layout
@@ -484,7 +484,7 @@
 			textcolor="grey"
 			font-weight=400
 			bgcolor="none"
-			selectedtextcolor="white"
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 			shadowtextcolor="darkestGrey"  // this is the cursor color
 	
@@ -511,7 +511,7 @@
 			font-size=12
 			textcolor="grey"
 			bgcolor="none"
-			selectedtextcolor="white"
+			selectedtextcolor="darkestGrey"
 			selectedbgcolor="blue"
 			shadowtextcolor="grey"	// this is the cursor color	
 		}

--- a/resource/styles/steam.styles
+++ b/resource/styles/steam.styles
@@ -194,7 +194,7 @@ colors {
 
     ListPanel.TextColor       grey
     ListPanel.BgColor       none  
-    ListPanel.SelectedTextColor     white
+    ListPanel.SelectedTextColor     darkestGrey
     ListPanel.SelectedBgColor     blue
     ListPanel.SelectedOutOfFocusBgColor   blue
     ListPanel.DisabledTextColor     darkestGrey
@@ -405,7 +405,7 @@ styles {
 		font-size=14
 		font-weight=400
 		textcolor  = "white"
-		selectedtextcolor  = "trueWhite"
+		selectedtextcolor  = "darkestGrey"
 		selectedbgcolor  = "Blue"
 		shadowtextcolor  = "TextDisabled"	// the color of disabled line items
 		inset  = "0 -1 1 1"
@@ -440,7 +440,7 @@ styles {
 		font-size=14
 		font-weight=400
 		textcolor  = "white"
-		selectedtextcolor  = "trueWhite"
+		selectedtextcolor  = "darkestGrey"
 		selectedbgcolor  = "Blue"
 		inset  = "0 -1 1 1"
 		bgcolor=none
@@ -471,7 +471,7 @@ styles {
       font-size=13
       font-weight=400
       textcolor  = "white"
-      selectedtextcolor  = "trueWhite"
+      selectedtextcolor  = "darkestGrey"
       selectedbgcolor  = "blue" //blue
       shadowtextcolor  = "grey"
       inset  = "0 -3 0 0"
@@ -490,7 +490,7 @@ styles {
 	// Games in Details List + List View that are not installed.
     "GameItem_Uninstalled" {
       textcolor  = "grey"
-      selectedtextcolor  = "white"
+      selectedtextcolor  = "darkestGrey"
       selectedbgcolor = "blue" //blue
     }
 	    "GameItem_Uninstalled:hover" {
@@ -500,13 +500,13 @@ styles {
  
     "GameItem_Installed" {
     	textcolor  = "white"
-		selectedtextcolor  = "trueWhite"
+		selectedtextcolor  = "darkestGrey"
 		selectedbgcolor = "blue" //blue
     }
       
 		"GameItem_Installed:hover" {
         	textcolor  = "white"
-			selectedtextcolor  = "trueWhite"
+			selectedtextcolor  = "darkestGrey"
 			selectedbgcolor = "blue" //blue
 		}
     
@@ -514,19 +514,19 @@ styles {
     "GameItem_Updating" {
     	padding-left=10
     	textcolor  = "orange"
-    	selectedtextcolor  = "trueWhite"
+    	selectedtextcolor  = "darkestGrey"
     	selectedbgcolor = "blue" //blue
     }
     
     	"GameItem_Updating:hover" {
     		textcolor  = "orange"
-    		selectedtextcolor  = "trueWhite"
+    		selectedtextcolor  = "darkestGrey"
     		selectedbgcolor = "blue" //blue
 		}
     
 		"GameItem_Updating:selected" {
  			textcolor  = "orange"
- 			selectedtextcolor  = "trueWhite"
+ 			selectedtextcolor  = "darkestGrey"
  			selectedbgcolor = "blue" //blue
  		}
     
@@ -534,61 +534,61 @@ styles {
     
     "GameItem_Shortcut" {
       textcolor  = "white"
-      selectedtextcolor  = "trueWhite"
+      selectedtextcolor  = "darkestGrey"
       selectedbgcolor = "blue" //blue
     }
       
 	    "GameItem_Shortcut:hover" {
 	        textcolor  = "white"
-	        selectedtextcolor  = "trueWhite"
+	        selectedtextcolor  = "darkestGrey"
 		selectedbgcolor = "blue" //blue
 	    }
     
     "GameItem_Mod" {
       textcolor  = "white"
-      selectedtextcolor  = "trueWhite"
+      selectedtextcolor  = "darkestGrey"
       selectedbgcolor = "blue" //blue
       }
       
 	    "GameItem_Mod:hover" {
 	        textcolor  = "white"
-	        selectedtextcolor  = "trueWhite"
+	        selectedtextcolor  = "darkestGrey"
 		selectedbgcolor = "blue" //blue
 	    }
     
     "GameItem_Decrypting" {
     	textcolor  = "orange"
-    	selectedtextcolor  = "trueWhite"
+    	selectedtextcolor  = "darkestGrey"
 	selectedbgcolor = "blue" //blue
     }
     
 	    "GameItem_Decrypting:hover" {
 	    	textcolor  = "orange"
-	    	selectedtextcolor  = "trueWhite"
+	    	selectedtextcolor  = "darkestGrey"
 		selectedbgcolor = "blue" //blue
 	    }
     
 	    "GameItem_Decrypting:selected" {
 	    	textcolor  = "orange"
-	    	selectedtextcolor  = "trueWhite"
+	    	selectedtextcolor  = "darkestGrey"
 		selectedbgcolor = "blue" //blue
 	    }
     
     "GameItem_Syncing" {
     	textcolor  = "orange"
-    	selectedtextcolor  = "trueWhite"
+    	selectedtextcolor  = "darkestGrey"
 	selectedbgcolor = "blue" //blue
     }
     
 	    "GameItem_Syncing:hover" {
 	    	textcolor  = "orange"
-	    	selectedtextcolor  = "trueWhite"
+	    	selectedtextcolor  = "darkestGrey"
 		selectedbgcolor = "blue" //blue
 	    }
 	    
 	    "GameItem_Syncing:selected" {
 	    	textcolor  = "orange"
-	    	selectedtextcolor  = "trueWhite"
+	    	selectedtextcolor  = "darkestGrey"
 		selectedbgcolor = "blue" //blue
 	    }
     
@@ -1002,7 +1002,7 @@ styles {
         
     RichText {
 		textcolor  = "white"
-		selectedtextcolor  = "trueWhite"	
+		selectedtextcolor  = "darkestGrey"
 		selectedbgcolor = blue	
 		font-family=basefont
 		font-size=13
@@ -1025,7 +1025,7 @@ styles {
 	"RichText url" {
 		font-size=13
 		textcolor  = "blue"
-		selectedtextcolor  = "white"
+		selectedtextcolor  = "darkestGrey"
 		font-style=underline
 	}
 	
@@ -1325,7 +1325,7 @@ styles {
 		font-size=14
 		font-family  = "Menlo" [$OSX]
       	font-size=16 [$OSX]
-		selectedtextcolor  = "trueWhite"
+		selectedtextcolor  = "darkestGrey"
 		selectedbgcolor  = "blue"
 	}
 	
@@ -1335,7 +1335,7 @@ styles {
 		font-family  = "Menlo" [$OSX]
       	font-size=14 [$OSX]
 	    textcolor  = "white"
-		selectedtextcolor  = "trueWhite"	
+		selectedtextcolor  = "darkestGrey"
 		selectedbgcolor  = "blue"
 	}
 	


### PR DESCRIPTION
Firstly, great work with the skin so far!

A small annoyance for me is the white text on a selected item, it's a little difficult to see.  Changing it to a dark colour is a lot more readable.

![Settings](https://cloud.githubusercontent.com/assets/4025899/4263785/24a94b7e-3c00-11e4-8035-93698f306527.png)
![Library](https://cloud.githubusercontent.com/assets/4025899/4263786/24b3e4b2-3c00-11e4-8a8d-3585f8ae54d8.png)
![Players](https://cloud.githubusercontent.com/assets/4025899/4263787/24b44b14-3c00-11e4-9916-c31f3e36702e.png)

This covers most cases, except text in the main menu and top drop-downs.
