### PR TITLE
Better menubar menu structure for Mac

### DIFF
--- a/resource/menus/steam.menu
+++ b/resource/menus/steam.menu
@@ -1,14 +1,14 @@
-"menubar" {
-	Steam {
-		text = [!$OSX]	"#steam_menu_file"
-		text = [$OSX]	"Menu"
+"menubar"
+{
+	Steam [$WINDOWS] {
+		text = "#steam_menu_file"
 		
 		SkinVersion {
 			text="Pressure BETA"
 			shellcmd="steam://openurl/http://steamcommunity.com/groups/pressureskin"
 		}
 		
-		About {	
+		About { 
 			text="#steam_about"
 			command="About" 
 		}
@@ -102,8 +102,8 @@
 			command="Settings"
 		}
 		
-		GoOnline {	
-			text="#SteamUI_OfflineMode_GoOnline"		
+		GoOnline {  
+			text="#SteamUI_OfflineMode_GoOnline"        
 			command="goonline" 
 		}
 		GoOffline {
@@ -111,7 +111,7 @@
 			command="gooffline" 
 		}
 		
-		Restart	[$WINDOWS] {
+		Restart {
 			text="#Steam_MustRestart_Button"
 			command="RestartSteam"
 		}
@@ -119,6 +119,363 @@
 		Exit {
 			text="#Steam_ExitSteam"
 			command="Exit"
-		}	
+		}   
+	}
+	
+	Store [$OSX] {
+		text="#steam_store"
+
+		Featured {
+			text="#steam_subnav_featured"
+			shellcmd="steam://url/StoreFrontPage"
+		}
+
+		Explore {
+			text="#steam_subnav_explore"
+			shellcmd="steam://url/StoreExplore"
+		}
+
+		Curators {
+			text="#steam_subnav_curators"
+			shellcmd="steam://url/StoreCurators"
+		}
+
+		Wishlist {
+			text="#steam_subnav_wishlist"
+			shellcmd="steam://url/UserWishlist"
+		}
+
+		News {
+			text="#steam_subnav_news"
+			shellcmd="steam://open/news"
+		}
+
+		Stats {
+			text="#steam_subnav_stats"
+			shellcmd="steam://url/StoreStats"
+		}
+
+		Divider {} // ________________________________________________________________________________________________________________________
+
+		RedeemWalletVoucher {
+			text="#Steam_RedeemWalletVoucher"
+			shellcmd="steam://url/RedeemWalletVoucher"
+		}
+	}
+
+	Library [$OSX] {
+		text="#steam_library"
+		
+		Games {
+			text="#steam_menu_view_games"
+			shellcmd="steam://nav/games"
+		}
+		
+		GamesDetails {
+			text="#steam_menu_games_details"
+			shellcmd="steam://nav/games/details"
+		}
+
+		GamesList    {
+			text="#steam_menu_games_list"
+			shellcmd="steam://nav/games/list"
+		}
+
+		GamesGrid    {
+			text="#steam_menu_games_grid"
+			shellcmd="steam://nav/games/grid"
+		}
+
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		MusicDetails {
+			text="#steam_menu_view_music_details"
+			shellcmd="steam://nav/music/details"
+		}
+		
+		MusicPlayer {
+			text="#steam_menu_view_musicplayer"
+			shellcmd="steam://open/musicplayer"
+		}
+
+		Divider {} // ________________________________________________________________________________________________________________________
+
+		AddShortcut {
+			text="#Steam_menu_AddShortcut"
+			shellcmd="steam://AddNonSteamGame"
+		}
+
+		ActivateRetail {
+			text="#Steam_RegisterProductCode"
+			command="ActivateRetail"
+		}
+
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		BackupGames {
+			text="#steam_menu_backupgames"
+			command="backupgames"
+		}
+	}
+
+	Community [$OSX] {
+		text="#steam_menu_community"
+
+		Home {
+			text="#steam_subnav_community_home"
+			shellcmd="steam://url/CommunityHome"
+		}
+
+		Discussions {
+			text="#steam_subnav_discussions"
+			shellcmd="steam://url/SteamDiscussions"
+		}
+
+		Workshop {
+			text="#steam_subnav_workshop"
+			shellcmd="steam://url/SteamWorkshop"
+		}
+
+		Greenlight {
+			text="#steam_subnav_greenlight"
+			shellcmd="steam://url/SteamGreenlight"
+		}
+
+		Market {
+			text="#steam_subnav_market"
+			shellcmd="steam://url/CommunityMarket"
+		}
+	}
+	
+	Friends [$OSX] {
+		text="#steam_menu_friends_view"
+
+		Activity {
+			text="#steam_subnav_activity"
+			shellcmd="steam://url/SteamIDControlPage"
+		}
+
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		ViewFriends {
+			text="#steam_menu_view_friends"
+			shellcmd="steam://open/friends"
+		}
+
+		AddFriend {
+			text="#steam_menu_add_friend"
+			shellcmd="steam://friends/add"
+		}
+
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		Online {
+			text="#friends_online"
+			shellcmd="steam://friends/status/online"
+			checkable=1
+		}
+		
+		Away {
+			text="#friends_away"
+			shellcmd="steam://friends/status/away"
+			checkable=1
+		}
+		
+		Play {
+			text="#friends_lookingtoplay"
+			shellcmd="steam://friends/status/play"
+			checkable=1
+		}
+		
+		Trade {
+			text="#friends_lookingtotrade"
+			shellcmd="steam://friends/status/trade"
+			checkable=1
+		}
+		
+		Busy {
+			text="#friends_busy"
+			shellcmd="steam://friends/status/busy"
+			checkable=1
+		}
+		
+		Offline  {
+			text="#friends_offline"
+			shellcmd="steam://friends/status/offline"
+			checkable=1
+		}
+		
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		SortByName  {
+			text="#steam_menu_friends_sortbyname"
+			shellcmd="steam://friends/settings/sortbyname"
+			checkable=1
+		}
+		
+		ShowAvatars {
+			text="#steam_menu_friends_showavatars"
+			shellcmd="steam://friends/settings/showavatars"
+			checkable=1
+		}
+		
+		OnlineUsersOnly {
+			text="#steam_menu_friends_hideoffline"
+			shellcmd="steam://friends/settings/hideoffline"
+			checkable=1
+		}
+		
+		ShowTagged {
+			text="#steam_menu_friends_showtagged"
+			shellcmd="steam://friends/settings/showtagged"
+			checkable=1
+		}
+	}
+
+	Steam [$OSX] {
+		text = "Me" 
+		
+		ViewProfile {
+			text="#steam_menu_account_view_profile" 
+			shellcmd="steam://url/SteamIDMyProfile"
+		}
+
+		EditProfile {
+			text="Edit Profile..."                  
+			shellcmd="steam://url/steam://url/SteamIDEditPage"
+		}
+
+		Divider {} // ________________________________________________________________________________________________________________________
+
+		AccountDetails {
+			text="#Steam_Account_Link"
+			shellcmd="steam://url/StoreAccount"
+		}
+
+		FamilySharing {
+			text="#Steam_AccountPage_ManageDeviceAuth"
+			shellcmd="steam://url/FamilySharing"
+		}
+
+		ManageGuestPasses {
+			text="#Steam_ManageGuestPasses"
+			command="ManageGuestPasses"
+		}
+
+		Divider {} // ________________________________________________________________________________________________________________________
+
+		ChangeUser {
+			text="#steam_menu_changeuser"
+			command="ChangeUser"
+		}
+
+		GoOnline {
+			text="#SteamUI_OfflineMode_GoOnline"
+			command="goonline"
+		}
+
+		GoOffline {
+			text="#SteamUI_OfflineMode_GoOffline"
+			command="gooffline"
+		}
+	}
+
+	View [$OSX] {
+		text="#steam_menu_view"
+
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		Inventory {
+			text="#steam_inventory"
+			shellcmd="steam://open/inventory"
+		}
+		
+		Screenshots {
+			text="#steam_screenshots"
+			command="Screenshots"
+		}
+		
+		ViewPlayerList {
+			text="#steam_menu_view_players"
+			shellcmd="steam://friends/players"
+		}
+		
+		Servers {
+			text="#steam_menu_servers"
+			shellcmd="steam://open/servers"
+		}
+		
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		MiniMode {
+			text="#steam_menu_minimode"
+			shellcmd="steam://open/minigameslist"
+		}
+		
+		LargeMode {
+			text="#steam_menu_largemode"
+			shellcmd="steam://open/largegameslist"
+		}
+	}
+
+	Window [$OSX] {
+		text="#steam_menu_window"
+
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		StartVR {
+			text="#steam_menu_startvr"
+			command="startvr"
+		}
+
+		BigPictureMode {
+			text="#steam_menu_bigpicturemode"
+			shellcmd="steam://open/bigpicture"
+		} 
+	}
+	
+	Help [$OSX] {
+		text="#steam_menu_help"
+		
+		Support {
+			text="#steam_menu_support"
+			command="Support"
+		}
+		
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		Privacy {
+			text="#steam_menu_PrivacyPolicy"
+			shellcmd="steam://url/PrivacyPolicy"
+		}
+		
+		Legal {
+			text="#steam_menu_LegalInformation"
+			shellcmd="steam://url/LegalInformation"
+		}
+		
+		SSA {
+			text="#steam_menu_SteamSubscriberAgreement"
+			shellcmd="steam://url/SSA"
+		}
+		
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		SystemInfo {
+			text="#steam_menu_systeminfo"
+			command="SystemInfo"
+		}
+		
+		About {
+			text="#steam_about"
+			command="About"
+		}
+		
+		Divider {} // ________________________________________________________________________________________________________________________
+		
+		SkinVersion {
+			text="Pressure BETA"
+			shellcmd="steam://openurl/http://steamcommunity.com/groups/pressureskin"
+		}
 	}
 }


### PR DESCRIPTION
This approach to Steam's menus makes full use of the menubar for those who want to use it, rather than just a 'Steam' and 'Menu' menu. Mac-only at the moment as I wasn't sure if these menus would be okay on Windows (untested).
![](http://i.imgur.com/RDXtWzM.png)
