### PR TITLE
Fix crash in Auto-Retry on Game Info dialog

### DIFF
--- a/servers/DialogGameInfo.res
+++ b/servers/DialogGameInfo.res
@@ -673,7 +673,7 @@
 			control=InfoLabel
 			
 			dir=down
-			width=300
+			width=310
 			align=left
 			x=16
 			y=16

--- a/servers/DialogGameInfo_AutoRetry.res
+++ b/servers/DialogGameInfo_AutoRetry.res
@@ -1,0 +1,703 @@
+"Servers\DialogGameInfo.res" {
+	"DialogGameInfo" {
+		"ControlName"		"CDialogGameInfo"
+		"fieldName"		"DialogGameInfo"
+		"xpos"		"100"
+		"ypos"		"100"
+		"wide"		"416"
+		"tall"		"440"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"settitlebarvisible"		"1"
+	}
+	
+	"Connect" {
+		"ControlName"		"Button"
+		"fieldName"		"Connect"
+		"xpos"		"122"
+		"ypos"		"400"
+		"wide"		"80"
+		"tall"		"24"
+		"autoResize"		"0"
+		"pinCorner"		"2"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"1"
+		"labelText"		"#ServerBrowser_JoinGame"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+		"Default"		"1"
+	}
+	
+	"Close" {
+		"ControlName"		"Button"
+		"fieldName"		"Close"
+		"xpos"		"312"
+		"ypos"		"400"
+		"wide"		"80"
+		"tall"		"24"
+		"autoResize"		"0"
+		"pinCorner"		"2"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"3"
+		"labelText"		"#ServerBrowser_Close"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+		"Default"		"0"
+	}
+	
+	"Refresh" {
+		"ControlName"		"Button"
+		"fieldName"		"Refresh"
+		"xpos"		"218"
+		"ypos"		"400"
+		"wide"		"80"
+		"tall"		"24"
+		"autoResize"		"0"
+		"pinCorner"		"2"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"2"
+		"labelText"		"#ServerBrowser_Refresh"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+		"Default"		"0"
+	}
+	
+	"InfoLabel" {
+		"ControlName"		"Label"
+		"fieldName"		"InfoLabel"
+		"xpos"		"26"
+		"ypos"		"371"
+		"wide"		"356"
+		"tall"		"24"
+		"autoResize"		"0"
+		"pinCorner"		"2"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"#ServerBrowser_AlertWhenSlotIsFree"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"AutoRetry" {
+		"ControlName"		"ToggleButton"
+		"fieldName"		"AutoRetry"
+		"xpos"		"28"
+		"ypos"		"400"
+		"wide"		"80"
+		"tall"		"24"
+		"autoResize"		"0"
+		"pinCorner"		"2"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"4"
+		"labelText"		"#ServerBrowser_AutoRetry"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+		"Default"		"0"
+		"selected"		"1"
+	}
+	
+	"AutoRetryAlert" {
+		"ControlName"		"RadioButton"
+		"fieldName"		"AutoRetryAlert"
+		"xpos"		"27"
+		"ypos"		"375"
+		"wide"		"358"
+		"tall"		"24"
+		"autoResize"		"0"
+		"pinCorner"		"2"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"5"
+		"labelText"		"#ServerBrowser_AlertMeWhenSlotOpens"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+		"Default"		"0"
+		"selected"		"0"
+		"SubTabPosition"		"1"
+	}
+	
+	"AutoRetryJoin" {
+		"ControlName"		"RadioButton"
+		"fieldName"		"AutoRetryJoin"
+		"xpos"		"28"
+		"ypos"		"396"
+		"wide"		"356"
+		"tall"		"24"
+		"autoResize"		"0"
+		"pinCorner"		"2"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"5"
+		"labelText"		"#ServerBrowser_JoinWhenSlotOpens"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+		"Default"		"0"
+		"selected"		"0"
+		"SubTabPosition"		"2"
+	}
+	
+	"PlayerList" {
+		"ControlName"		"ListPanel"
+		"fieldName"		"PlayerList"
+		"xpos"		"24"
+		"ypos"		"228"
+		"wide"		"368"
+		"tall"		"140"
+		"autoResize"		"3"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+	}
+	
+	"SysMenu" {
+		"ControlName"		"Menu"
+		"fieldName"		"SysMenu"
+		"xpos"		"0"
+		"ypos"		"0"
+		"zpos"		"1"
+		"wide"		"64"
+		"tall"		"24"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"0"
+		"enabled"		"1"
+		"tabPosition"		"0"
+	}
+	
+	"ServerLabel" {
+		"ControlName"		"Label"
+		"fieldName"		"ServerLabel"
+		"xpos"		"16"
+		"ypos"		"42"
+		"wide"		"108"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"#ServerBrowser_ServerName"
+		"textAlignment"		"east"
+		"dulltext"		"1"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"GameLabel" {
+		"ControlName"		"Label"
+		"fieldName"		"GameLabel"
+		"xpos"		"16"
+		"ypos"		"90"
+		"wide"		"108"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"#ServerBrowser_GameLabel"
+		"textAlignment"		"east"
+		"dulltext"		"1"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"ServerIPLabel" {
+		"ControlName"		"Label"
+		"fieldName"		"ServerIPLabel"
+		"xpos"		"16"
+		"ypos"		"66"
+		"wide"		"108"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"#ServerBrowser_IPAddressLabel"
+		"textAlignment"		"east"
+		"dulltext"		"1"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"MapLabel" {
+		"ControlName"		"Label"
+		"fieldName"		"MapLabel"
+		"xpos"		"16"
+		"ypos"		"114"
+		"wide"		"108"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"#ServerBrowser_MapLabel"
+		"textAlignment"		"east"
+		"dulltext"		"1"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"PlayersLabel" {
+		"ControlName"		"Label"
+		"fieldName"		"PlayersLabel"
+		"xpos"		"16"
+		"ypos"		"138"
+		"wide"		"108"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"#ServerBrowser_PlayersLabel"
+		"textAlignment"		"east"
+		"dulltext"		"1"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"PingLabel" {
+		"ControlName"		"Label"
+		"fieldName"		"PingLabel"
+		"xpos"		"16"
+		"ypos"		"186"
+		"wide"		"108"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"#ServerBrowser_LatencyLabel"
+		"textAlignment"		"east"
+		"dulltext"		"1"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"ServerText" {
+		"ControlName"		"Label"
+		"fieldName"		"ServerText"
+		"xpos"		"128"
+		"ypos"		"42"
+		"wide"		"260"
+		"tall"		"20"
+		"autoResize"		"1"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"Counter-Strike Source dedicated server"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"GameText" {
+		"ControlName"		"Label"
+		"fieldName"		"GameText"
+		"xpos"		"128"
+		"ypos"		"90"
+		"wide"		"260"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"Counter-Strike: Source"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"ServerIPText" {
+		"ControlName"		"TextEntry"
+		"fieldName"		"ServerIPText"
+		"xpos"		"128"
+		"ypos"		"64"
+		"wide"		"260"
+		"tall"		"24"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"0"
+		"tabPosition"		"0"
+		"textHidden"		"0"
+		"editable"		"0"
+		"maxchars"		"-1"
+		"NumericInputOnly"		"0"
+		"unicode"		"0"
+	}
+	
+	"MapText" {
+		"ControlName"		"Label"
+		"fieldName"		"MapText"
+		"xpos"		"128"
+		"ypos"		"114"
+		"wide"		"260"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"cs_compound"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"PlayersText" {
+		"ControlName"		"Label"
+		"fieldName"		"PlayersText"
+		"xpos"		"128"
+		"ypos"		"138"
+		"wide"		"260"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"0 / 24"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"PingText" {
+		"ControlName"		"Label"
+		"fieldName"		"PingText"
+		"xpos"		"128"
+		"ypos"		"186"
+		"wide"		"260"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"12"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"Label1" {
+		"ControlName"		"Label"
+		"fieldName"		"Label1"
+		"xpos"		"15"
+		"ypos"		"162"
+		"wide"		"108"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"#ServerBrowser_ValveAntiCheat"
+		"textAlignment"		"east"
+		"dulltext"		"1"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	"SecureText" {
+		"ControlName"		"Label"
+		"fieldName"		"SecureText"
+		"xpos"		"128"
+		"ypos"		"162"
+		"wide"		"260"
+		"tall"		"20"
+		"autoResize"		"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"		"0"
+		"labelText"		"#ServerBrowser_Secure"
+		"textAlignment"		"west"
+		"dulltext"		"0"
+		"brighttext"		"0"
+		"wrap"		"0"
+	}
+	
+	styles {
+		CDialogGameInfo {
+			minimum-width=620
+			minimum-height=408
+		}
+		
+		LabelDull {
+			font-size=20
+			font-family=headerfont
+			textcolor=white
+		}
+		
+		label {
+			textcolor=lightestGrey
+			font-size=14
+		}
+		
+		textEntry {
+			textcolor=lightestGrey
+			font-size=14
+			
+			inset-left=0
+		
+			render {}
+			render_bg{}
+		}
+		
+	}	
+
+	layout {
+		place [!$OSX]  { 
+			control="frame_minimize,frame_close" 
+			align=right 
+			margin-top=-2 
+			margin-right=6 
+			spacing=-9 
+		}
+		
+		region {
+			name=left
+			margin-top=38
+			margin-bottom=52
+			width=max
+			margin-right=416
+			height=max
+			x=8
+		}
+		
+		// Server Name
+		place { 
+			region=left 
+			control=ServerLabel 
+			dir=down 
+			spacing=0
+			margin-left=0 
+		}
+		// We seperate the value from the header to avoid a weird width-bug that cuts off text
+		place {
+			region=left
+			control=ServerText
+			start=ServerLabel
+			dir=down
+			margin-top=-4
+			width=max
+		}
+		
+		// SERVER IP
+		place { 
+			region=left 
+			control=ServerIPLabel
+			start=ServerText
+			dir=down 
+			spacing=0
+			margin-top=16 
+			margin-left=0 
+		}
+		// We seperate the value from the header to avoid a weird width-bug that cuts off text
+		place {
+			region=left
+			control=ServerIPText
+			start=ServerIPLabel
+			dir=down
+			margin-top=-8
+			margin-left=-2
+			width=max
+		}
+
+		// GAME
+		place { 
+			region=left 
+			control=GameLabel
+			start=ServerIPText
+			dir=down 
+			spacing=0
+			margin-top=16 
+			margin-left=0 
+		}
+		// We seperate the value from the header to avoid a weird width-bug that cuts off text
+		place {
+			region=left
+			control=GameText
+			start=GameLabel
+			dir=down
+			margin-top=-4
+			width=max
+		}
+
+		// MAP
+		place { 
+			region=left 
+			control=MapLabel
+			start=GameText
+			dir=down 
+			spacing=0
+			margin-top=16 
+			margin-left=0 
+		}
+		// We seperate the value from the header to avoid a weird width-bug that cuts off text
+		place {
+			region=left
+			control=MapText
+			start=MapLabel
+			dir=down
+			margin-top=-4
+			width=max
+		}
+		
+
+		// PLAYERS
+		place { 
+			region=left 
+			control=PlayersLabel
+			start=MapText
+			dir=down 
+			spacing=0
+			margin-top=16
+			margin-left=0 
+		}
+		// We seperate the value from the header to avoid a weird width-bug that cuts off text
+		place {
+			region=left
+			control=PlayersText
+			start=PlayersLabel
+			dir=down
+			margin-top=-4
+			width=max
+		}
+
+		// VAC
+		place { 
+			region=left 
+			control=Label1
+			start=PlayersText
+			dir=down 
+			spacing=0
+			margin-top=16
+			margin-left=0 
+		}
+		// We seperate the value from the header to avoid a weird width-bug that cuts off text
+		place {
+			region=left
+			control=SecureText
+			start=label1
+			dir=down
+			margin-top=-4
+			width=max
+		}
+		
+		
+		// Lag
+		place { 
+			region=left 
+			control=PingLabel
+			start=SecureText
+			dir=down 
+			spacing=0
+			margin-top=16
+			margin-left=0 
+		}
+		// We seperate the value from the header to avoid a weird width-bug that cuts off text
+		place {
+			region=left
+			control=PingText
+			start=PingLabel
+			dir=down
+			margin-top=-4
+			width=max
+		}
+		
+		
+		
+		region {
+			name=right
+			align=right
+			width=400
+			height=max
+			margin-top=26
+			margin-bottom=52
+		}
+		
+		place {
+			region=right
+			control="PlayerList"
+			align=right
+			width=max
+			height=max
+			margin-bottom=51
+		}
+		
+		place { 
+			region=right 
+			start=PlayerList 
+			control="AutoRetryAlert,AutoRetryJoin" 
+			width=max 
+			height=24
+			dir=down 
+		}
+		
+		place {
+			region="bottom"
+			control=InfoLabel
+			
+			dir=down
+			width=300
+			align=left
+			x=16
+			y=16
+		}
+		
+		
+		//Bottom
+		region { 
+			name=bottom 
+			align=bottom 
+			height=51
+		}
+		
+		place {	
+			control="AutoRetry,Connect,Refresh,Close" 
+			region=bottom 
+			align=right 
+			spacing=8 
+			height=24
+			margin-top=13
+			margin-right=13
+		}		
+	}
+}

--- a/servers/DialogGameInfo_AutoRetry.res
+++ b/servers/DialogGameInfo_AutoRetry.res
@@ -676,7 +676,7 @@
 			control=InfoLabel
 			
 			dir=down
-			width=300
+			width=310
 			align=left
 			x=16
 			y=16


### PR DESCRIPTION
Fixes #150 
This file is a copy of DialogGameInfo, but the "visible" and "selected"
keys for "AutoRetry", "AutoRetryJoin", and "AutoRetryAlert" have changed
or been added.

This might also have to be done for DialogGameInfo_NoSteam.res