### PR TITLE
Recolor game list text for uninstalled games

### DIFF
--- a/resource/styles/steam.styles
+++ b/resource/styles/steam.styles
@@ -404,12 +404,12 @@ styles {
     "GameItem_Uninstalled" {
       padding-left=10
       textcolor  = "grey"
-      selectedtextcolor  = "white"
+      selectedtextcolor  = "lighterGrey"
       //selectedbgcolor = "blue" //blue
     }
 	    "GameItem_Uninstalled:hover" {
     	    textcolor  = "grey"
-			selectedtextcolor  = "white"
+			selectedtextcolor  = "lighterGrey"
 		//selectedbgcolor = "blue" //blue
 		}
  


### PR DESCRIPTION
This allows for telling the difference between a game that is installed and one that isn't when it is selected in the game list. Uninstalled games will have darker text even when selected (instead of white).

Prior to this, when you selected a game, you could no longer tell whether it was installed or not.