### PR TITLE
Add Video Decode button

### DIFF
--- a/steam/cached/SettingsSubInterface.res
+++ b/steam/cached/SettingsSubInterface.res
@@ -341,18 +341,18 @@
 		}
 		
 		place {
-			controls=AutoLaunchCheck,BigPictureModeCheck,DWriteCheck,UrlBarCheck
+			controls=AutoLaunchCheck,BigPictureModeCheck,DWriteCheck,UrlBarCheck,H264HWAccelCheck
 			dir=down
 			start=SkinCombo
-			y=16
+			y=10
 			spacing=-4
 		}
 		
 		place {
 			control="Divider2"
 			dir=down
-			start=UrlBarCheck
-			y=16
+			start=H264HWAccelCheck
+			y=10
 			width=max
 			margin-right=43
 		}


### PR DESCRIPTION
Fixes #176

Had to move some things up a little bit cause you were running out of room, the taskbar button was on the footer

Preview: 
![image](https://cloud.githubusercontent.com/assets/6258213/6057271/83dd31be-ad70-11e4-846c-f2e552d1fcaf.png)
