### PR TITLE
Add DLC Details to library view

### DIFF
--- a/resource/layout/gamespage_details_dlc.layout
+++ b/resource/layout/gamespage_details_dlc.layout
@@ -38,12 +38,6 @@
 			style="dlclist"
 		}
 
-		managedlc {
-			controlname="Button"
-			labeltext="#Steam_ManageDLC"
-			command="ManageDLC"
-		}
-
 		moredlc {
 			controlname="Button"
 			labeltext="#Steam_FindDLCInStore"
@@ -147,14 +141,15 @@
 			region=body
 			y=35
 			x=267
-			control=dlclist dir=down
+			control=dlclist
+			dir=down
 		}
 
 		place {
 			region=body
 			y=165
 			x=267
-			control=managedlc,moredlc
+			control=moredlc
 			dir=right
 			spacing=10
 		}

--- a/resource/layout/gamespage_details_dlc.layout
+++ b/resource/layout/gamespage_details_dlc.layout
@@ -1,0 +1,162 @@
+"resource/layout/gamespage_details_dlc.layout"
+{
+	controls
+	{
+		dlcdetails {
+			controlname="CGamesPage_Details_DLC"
+			style="dlcdetails"
+		}
+
+		headerlabel {
+			controlname="Label"
+			style="gamedetails-headerlabel"
+			labeltext="#Steam_DLC_Details"
+		}
+
+		latestimage {
+			controlname="ImagePanel"
+			style="mostrecentimage"
+			scaling="fit"
+		}
+
+		overlayimage {
+			controlname"ImagePanel"
+			style="overlayimage"
+			scaling="fit"
+			zpos=2
+			image="resource/dlc_overlay"
+		}
+
+		latesttimelabel {
+			controlname="Label"
+			style="mostrecenttime"
+			labeltext="#Steam_DLC_LatestItemAdded"
+		}
+
+		dlclist {
+			controlname="ListPanel"
+			style="dlclist"
+		}
+
+		managedlc {
+			controlname="Button"
+			labeltext="#Steam_ManageDLC"
+			command="ManageDLC"
+		}
+
+		moredlc {
+			controlname="Button"
+			labeltext="#Steam_FindDLCInStore"
+			command="FindDLCInStore"
+		}
+	}
+
+	colors
+	{
+		RichText.InsetX "0"
+		RichText.InsetY "3" 
+		GameDetailsDLC.ExtraVerticalSpacing "229"
+	}
+
+	styles
+	{
+
+		// This overrides the default button.
+		button {
+			textcolor=blue
+			padding=0
+			
+			render_bg {
+				0="image(x1-5, y1-14, x1, y1-10, graphics/details_button)"
+			}
+		}
+			
+		button:hover {
+			textcolor=lightestBlue
+		}
+
+		dlcdetails { 
+			bgcolor=black65
+		}
+
+		bodycontent
+		{
+			textcolor="Label"
+			selectedtextcolor="Label"	
+			font-size=15
+			render_bg {}
+		}
+
+		"DLC_Uninstalled"
+		{
+			textcolor="labeldisabled"
+			selectedtextcolor="label"
+		}
+
+		"DLC_Installed"
+		{
+			textcolor="text"
+			selectedtextcolor="white"
+		}
+	}
+
+	layout
+	{
+		region {
+			name=body
+			margin=20
+			width=max
+			height=max
+		}
+
+		place {
+			region=body
+			control=headerlabel
+			width=max
+		}
+
+		place {
+			region=body
+			y=35
+			control=latestimage
+			width=257
+			height=120
+		}
+
+		place {
+			region=body
+			y=35
+			control=overlayimage
+			width=257
+			height=120 
+		}
+
+		place {
+			region=body
+			y=168
+			control=latesttimelabel
+		}
+
+		place {
+			control=dlclist
+			height=120
+			width=max
+		}
+
+		place {
+			region=body
+			y=35
+			x=267
+			control=dlclist dir=down
+		}
+
+		place {
+			region=body
+			y=165
+			x=267
+			control=managedlc,moredlc
+			dir=right
+			spacing=10
+		}
+	}
+}

--- a/resource/layout/steamrootdialog_gamespage_details.layout
+++ b/resource/layout/steamrootdialog_gamespage_details.layout
@@ -152,6 +152,11 @@
 			controlname="CGamesPage_Details_Welcome" 
 			zpos="1" 
 		}
+
+		dlcdetails {
+			controlname="CGamesPage_Details_DLC"
+			zpos="1"
+		}
 		
 		friendsdetails { 
 			controlname="CGamesPage_Details_Friends" 
@@ -520,7 +525,7 @@
 		
 		// Body contents
 		place { 
-			control=friendsdetails,achievementsdetails,clouddetails,screenshotsdetails,communityfilesdetails,newsdetails,nonsteamdetails
+			control=dlcdetails,friendsdetails,achievementsdetails,clouddetails,screenshotsdetails,communityfilesdetails,newsdetails,nonsteamdetails
 			region=detailsbody
 			dir=down
 			width=max

--- a/resource/layout/steamrootdialog_gamespage_details.layout
+++ b/resource/layout/steamrootdialog_gamespage_details.layout
@@ -525,7 +525,7 @@
 		
 		// Body contents
 		place { 
-			control=dlcdetails,friendsdetails,achievementsdetails,clouddetails,screenshotsdetails,communityfilesdetails,newsdetails,nonsteamdetails
+			control=friendsdetails,achievementsdetails,dlcdetails,clouddetails,screenshotsdetails,communityfilesdetails,newsdetails,nonsteamdetails
 			region=detailsbody
 			dir=down
 			width=max


### PR DESCRIPTION
Steam beta recently added viewing owned DLC for a game in the library view.

Displays under the friends and achievment panels

Preview:
![image](https://cloud.githubusercontent.com/assets/6258213/6073199/4839ada6-adff-11e4-9271-29e0146b7daf.png)

#175 