### PR TITLE
Fix divider lines in Settings + Valve changes to Browser tab

### DIFF
--- a/resource/layout/settingssubbroadcast.layout
+++ b/resource/layout/settingssubbroadcast.layout
@@ -1,0 +1,74 @@
+"resource/layout/settingssubbroadcast.layout"
+{
+	controls
+	{
+		"BroadcastDisabledLabel" { ControlName="Label" fieldName="BroadcastDisabledLabel" labelText="#Steam_Settings_Broadcast_Disabled_System" wrap="1" group="ShowWhenDisabled" }
+		"BroadcastDisabledSupportURL" { ControlName="URLLabel" fieldName="BroadcastDisabledSupportURL" group="ShowWhenDisabled" }
+		
+		"BroadcastStatusHeader" { ControlName="Label" fieldName="BroadcastStatusHeader" labelText="#Steam_Settings_Broadcast_StatusHeader" group="HideWhenUnavailable" }
+		"BroadcastStatus" { ControlName="URLLabel" labeltext="#Steam_Settings_Broadcast_StatusNotBroadcast" style="rightcolumnlink" fieldName="BroadcastStatus" group="HideWhenUnavailable" }
+    
+		"BroadcastHelpHeader" { ControlName="Label" fieldName="BroadcastHelpHeader" labelText="#Steam_Settings_Broadcast_HelpHeader" group="HideWhenUnavailable" }
+		"BroadcastHelpURL" { ControlName="URLLabel" fieldName="BroadcastHelpURL" labelText="#Steam_Settings_Broadcast_HelpURL_Desc" URLText="#Steam_Settings_Broadcast_HelpURL_URL" group="HideWhenUnavailable" }
+		
+		"Divider1" { ControlName="Divider" }
+		
+		"PermissionsHeader" { ControlName="Label" fieldName="PermissionsHeader" labelText="#Steam_Settings_Broadcast_PermissionsHeader" group="HideWhenUnavailable" }
+		"Permissions" { ControlName="ComboBox" fieldName="Permissions" editable="0" group="HideWhenUnavailable" }			
+		
+		"DimensionsHeader" { ControlName="Label" fieldName="DimensionsHeader" labelText="#Steam_Settings_Broadcast_DimensionsHeader" group="HideWhenDisabled" }
+		"Dimensions" { ControlName="ComboBox" fieldName="Dimensions" group="HideWhenDisabled" editable="0" }
+		
+		"BitrateLimitHeader" { ControlName="Label" fieldName="BitrateLimitHeader" labelText="#Steam_Settings_Broadcast_BitrateHeader" group="HideWhenDisabled" }
+		"BitrateLimit" { ControlName="ComboBox" fieldName="BitrateLimit" group="HideWhenDisabled" editable="0" }
+		
+		"EncoderHeader" { ControlName="Label" fieldName="EncoderHeader" labelText="#Steam_Settings_Broadcast_EncoderHeader" group="HideWhenDisabled" }
+		"EncoderSetting" { ControlName="ComboBox" fieldName="EncoderSetting" group="HideWhenDisabled" editable="0" }
+		
+		"ShowChatHeader" { ControlName="Label" fieldName="ShowChatHeader" labelText="#Steam_Settings_Broadcast_ShowChat" group="HideWhenDisabled" }
+		"ShowChatCombo" { ControlName="ComboBox" fieldName="ShowChatCombo" group="HideWhenDisabled" editable="0" }
+		
+		"IncludeDesktop" { ControlName="CheckButton" fieldName="IncludeDesktop" group="HideWhenDisabled" }
+		"RecordMic" { ControlName="CheckButton" fieldName="RecordMic" group="HideWhenDisabled" }
+		"ConfigMic" { ControlName="URLLabel" fieldName="ConfigMic" labelText="#Steam_Settings_Broadcast_ConfigMic" URLText="steam://settings/voice" group="HideWhenDisabled" }
+		"EnableHardwareSupport" { ControlName="CheckButton" fieldName="EnableHardwareSupport" visible="0" }
+		"ShowDebugInfo" { ControlName="CheckButton" fieldName="ShowDebugInfo" group="HideWhenDisabled" }
+		"ShowReminder" { ControlName="CheckButton" fieldName="ShowReminder" group="HideWhenDisabled" }
+		
+		"RequiresRestartLabel" { ControlName="Label" fieldName="RequiresRestartLabel" labelText="#Steam_Settings_Broadcast_RequiresRestart" visible="0" }
+	}
+	
+	layout
+	{
+		place { control="BroadcastDisabledLabel" margin-left=20 margin-right=20 margin-top=32 width=max }
+		place { start="BroadcastDisabledLabel" control="BroadcastDisabledSupportURL" dir=down margin-top=10 margin-right=20 width=max }
+		
+		place { control="BroadcastStatusHeader" margin-left=20 margin-right=20 margin-top=20 }
+		place { start="BroadcastStatusHeader" control="BroadcastStatus" dir=right margin-left=4 }
+		
+		place { start="BroadcastStatusHeader" margin-top=4 control="BroadcastHelpHeader" dir=down }
+		place { start="BroadcastStatus" margin-top=4 control="BroadcastHelpURL" dir=down }
+		
+		place { start="BroadcastHelpHeader" control="Divider1" dir=down margin-top=15 width=max margin-right=43 }						
+		
+		place { start="Divider1" control="PermissionsHeader" dir=down margin-top=20 width=max }
+		place { start="PermissionsHeader" control="Permissions" dir=down margin-top=4 width=350 }
+		
+		place { start="Permissions" control="DimensionsHeader" dir=down margin-top=10 width=max }
+		place { start="DimensionsHeader" control="Dimensions" dir=down margin-top=4 width=250 }
+		
+		place { start="Dimensions" control="BitrateLimitHeader" dir=down margin-top=10 width=max }
+		place { start="BitrateLimitHeader" control="BitrateLimit" dir=down margin-top=4 width=250 }
+		
+		place { start="BitrateLimit" control="EncoderHeader" dir=down margin-top=10 width=max }
+		place { start="EncoderHeader" control="EncoderSetting" dir=down margin-top=4 width=250 }
+		
+		place { start="EncoderSetting" control="ShowChatHeader" dir=down margin-top=10 width=max }
+		place { start="ShowChatHeader" control="ShowChatCombo" dir=down margin-top=4 width=250 }
+				
+		place { start="ShowChatCombo" control="IncludeDesktop,RecordMic,EnableHardwareSupport,ShowDebugInfo,ShowReminder" dir=down margin-top=10 }	
+		place { start="RecordMic" control="ConfigMic" dir=right margin-top=6  }	
+		
+		place { control="RequiresRestartLabel" margin-left=20 margin-right=20 width=max margin-top=500 }
+	}
+}

--- a/resource/layout/subpaneloptionsbrowser.layout
+++ b/resource/layout/subpaneloptionsbrowser.layout
@@ -2,7 +2,6 @@
 {
 	controls
 	{
-		TitleLabel { controlname=label labeltext="#Steam_Settings_BrowserTitle" style=highlight }
 		DescriptionLabel	{ ControlName=Label labeltext="#Overlay_SettingsBrowserDesc" wrap=1  }
 		Divider1 { ControlName=Divider	}
 
@@ -33,16 +32,11 @@
 	
 	layout
 	{
-		region { name=box margin-top=10 margin-bottom=20 margin-left=20 margin-right=20 width=max height=max }
-		region { name=top region=box margin-top=10 }
-		region { name=topleft region=top y=30 width=max margin-right=20 }
-		region { name=bottom region=box y=100 }
-		
-		place { controls=TitleLabel region=top }
-		place { controls=DescriptionLabel height=40 width=max region=top start=TitleLabel dir=down margin-top=8 }
-		place { controls=OverlayHomePageLabel,OverlayHomePage, dir=down spacing=5 margin-top=20 width=max region=topleft }
-		place { controls=Divider1 start=OverlayHomePage dir=down region=bottom width=max margin-top=16 }
-		place { controls=ClearAllCookiesButton height=28 width=240 region=bottom start=Divider1 dir=down margin-top=16 }
+		place { controls=DescriptionLabel margin-top=20 margin-left=20 margin-right=43 width=max }
+		place { start=DescriptionLabel controls=OverlayHomePageLabel dir=down margin-top=20 width=200 }
+		place { start=OverlayHomePageLabel controls=OverlayHomePage dir=down margin-top=5 width=max margin-right=43 }
+		place { start=OverlayHomePage controls=Divider1 dir=down region=bottom width=max margin-top=15 margin-right=43 }
+		place { controls=ClearAllCookiesButton height=28 width=240 region=bottom start=Divider1 dir=down margin-top=15 }
 		
 	}
 }

--- a/resource/layout/subpaneloptionsdownloads.layout
+++ b/resource/layout/subpaneloptionsdownloads.layout
@@ -332,6 +332,7 @@
 			width=max
 			start=DownloadRegionCombo
 			y=16
+			margin-right=43
 		}
 
 		place {


### PR DESCRIPTION
Result: https://imgur.com/a/xFZJ4
In a few Settings pages, the divider lines would extend all the way to the right edge. This adds a size 43 margin for those, which matches the other dividers.
There were also some strange spacing issues on the Broadcast tab.