### PR TITLE
Fix legibility issues on trade notification

### DIFF
--- a/friends/tradeinvitebar.res
+++ b/friends/tradeinvitebar.res
@@ -60,13 +60,8 @@
 		}
 
 		Label {
-			textcolor=white
-			font-family=basefont
-			
-			font-style="outerglow"
-			font-outerglow-color="95 139 21 255"
-			font-outerglow-offset=1
-			font-outerglow-filtersize=3
+			textcolor=black90
+			font-family=semibold
 		}
 
 		Button {


### PR DESCRIPTION
After recently receiving a request to trade, the white text with a very light green background was quite hard to see, especially in the overlay where the colors weren't right.

Changed them to black90 with semibold which is much easier to see against a light background;
![image](https://cloud.githubusercontent.com/assets/6258213/6096835/2f87e3de-affa-11e4-910d-51835cf68861.png)
