### PR TITLE
Fix friend categ. not always having highlight line

### DIFF
--- a/friends/FriendsDialog.res
+++ b/friends/FriendsDialog.res
@@ -194,7 +194,7 @@
 			render_bg {
 				0="gradient(x0-22, y0+1, x1, y1, grey, lightGreyEnd)"
 				1="fill(x0-22, y0, x1, y0+1, greyHighlight)"
-				2="gradient(x0-22,y1,x1,y1+2, black65, none)"
+				2="gradient(x0-22,y1,x1,y1+1, black65, none)"
 			}    
 	    }
     


### PR DESCRIPTION
It's a really subtle issue but it gets noticeable if you have a lot of categories and just one of them is missing the highlight line.
Here's an example, notice the "ULATEDCHAOS" header is missing its highlight line (the lighter line at the top of it), making it appear pushed in/inset compared to the other headers:
http://i.imgur.com/tXFVyXo.png

Note the third one in the example is if you change the relevant "y1" to "y1-1" and leave the second one at "y1+1". Even though it makes the dividers even with the top divider, I think leaving it at "y1" is better because of the way the thicker bar at the top separates the friend list from the stuff above it.