### PR TITLE
Pressure Steam group link using GID instead of URL

### DIFF
--- a/resource/menus/steam.menu
+++ b/resource/menus/steam.menu
@@ -4,7 +4,7 @@
 		
 		SkinVersion {
 			text="Pressure BETA"
-			shellcmd="steam://openurl/http://steamcommunity.com/groups/pressureskin"
+			shellcmd="steam://url/GroupSteamIDPage/103582791435510416"
 		}
 		
 		About { 


### PR DESCRIPTION
There's a urllist.txt defines GroupSteamIDPage (and a few other things)
that are used like this.

This is mainly just an example, but it's possible we can use the urllist.txt stuff to replace that 'Recent players' thing on overlay.