### PR TITLE
Changed achievement description color in overlay to make it readable.

### DIFF
--- a/resource/layout/overlay_achievement_item.layout
+++ b/resource/layout/overlay_achievement_item.layout
@@ -1,7 +1,7 @@
 "resource/layout/overlay_achievement_item.layout" {
 	styles {
 		label {
-			textcolor=greyHighlight
+			textcolor=white
 			font-size=15
 		}
 	


### PR DESCRIPTION
The current color and background in the achievement overlay is grey and is very difficult to read.