### PR TITLE
Adjust appearance of FriendPanel invite links

### DIFF
--- a/resource/layout/friendpanel.layout
+++ b/resource/layout/friendpanel.layout
@@ -70,10 +70,12 @@ font-size=14 [$LINUX]
 
 		inviteLinkStyle {
 			textcolor=blue
+			font-style=normal
 		}
 
 			inviteLinkStyle:hover {
 				textcolor=lightestBlue
+				font-style=underline
 			}
 
 		WebStatusStyle {

--- a/resource/layout/friendpanel_compact.layout
+++ b/resource/layout/friendpanel_compact.layout
@@ -61,13 +61,13 @@ font-size=14 [$LINUX]
 			}
 
 		inviteLinkStyle {
-			textcolor=Text2
+			textcolor=blue
 			font-style="normal"
 			padding-left=2
 		}
 
 			inviteLinkStyle:hover {
-				textcolor=White
+				textcolor=lightestBlue
 				font-style=underline
 			}
 	}


### PR DESCRIPTION
Two things:
Makes compact FriendPanel links blue/lightblue instead of grey/white.
Makes regular FriendPanel links only underline on hover.
This causes the appearance and behavior to match between the two.