### PR TITLE
Remove use of openurl in menus, fix menu divider

### DIFF
--- a/resource/menus/steam.menu
+++ b/resource/menus/steam.menu
@@ -1,143 +1,145 @@
 "menubar" {
 	Steam [!$OSX] {
 		text = "#steam_menu_file"
-		
+
 		SkinVersion {
 			text="Pressure BETA"
 			shellcmd="steam://url/GroupSteamIDPage/103582791435510416"
 		}
-		
-		About { 
+
+		About {
 			text="#steam_about"
-			command="About" 
+			command="About"
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		ChangeUser {
 			text="#steam_menu_changeuser"
-			command="ChangeUser" 
+			command="ChangeUser"
 		}
-		
+
 		MyAccount {
 			text="#steam_menu_account_details"
-			shellcmd="steam://url/StoreAccount/" 
+			shellcmd="steam://url/StoreAccount/"
 		}
-				
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		BigPictureMode {
 			text="#steam_menu_bigpicturemode"
-			shellcmd="steam://open/bigpicture" 
-		} 
-	
+			shellcmd="steam://open/bigpicture"
+		}
+
 		MiniMode [!$OSX] {
 			text="#steam_menu_minimode"
 			shellcmd="steam://open/minigameslist"
 		}
 
+		Divider {} // ________________________________________________________________________________________________________________________
+
 		LargeMode [!$OSX] {
 			text="#steam_menu_largemode"
 			shellcmd="steam://open/largegameslist"
-		} 
-		
+		}
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		MusicDetails {
 			text="#steam_menu_view_music_details"
-			shellcmd="steam://nav/music/details" 
+			shellcmd="steam://nav/music/details"
 		}
-		
+
 		MusicPlayer {
 			text="#steam_menu_view_musicplayer"
-			shellcmd="steam://open/musicplayer" 
+			shellcmd="steam://open/musicplayer"
 		}
-		
-		Divider {} 
-		
+
+		Divider {}
+
 		Screenshots {
 			text="#steam_screenshots"
 			command="Screenshots"
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		Friends {
 			text="#steam_menu_friends"
 			shellcmd="steam://open/friends"
 		}
-		
+
 		ViewPlayerList {
 			text="#steam_menu_view_players"
-			shellcmd="steam://openurl/http://steamcommunity.com/my/friends/coplay" 
+			shellcmd="steam://url/RecentlyPlayedWith"
 		}
-		
+
 		Servers {
 			text="#steam_menu_servers"
-			shellcmd="steam://open/servers" 
+			shellcmd="steam://open/servers"
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		ActivateRetail {
 			text="#Steam_RegisterProductCode"
 			command="ActivateRetail"
 		}
-		
+
 		AddShortcut {
 			text="#Steam_menu_AddShortcut"
 			shellcmd="steam://AddNonSteamGame"
 		}
-		
+
 		BackupGames {
 			text="#steam_menu_backupgames"
 			command="backupgames"
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		AddFunds {
-			text="Add Funds to Steam Wallet" 
-			shellcmd="steam://openurl/http://store.steampowered.com/steamaccount/addfunds"
+			text="Add Funds to Steam Wallet"
+			shellcmd="steam://url/StoreAddFundsPage"
 		}
-		
+
 		RedeemWalletVoucher {
 			text="#Steam_RedeemWalletVoucher"
-			shellcmd="steam://url/RedeemWalletVoucher" 
+			shellcmd="steam://url/RedeemWalletVoucher"
 		}
-		
+
 		ManageGuestPasses {
 			text="#Steam_ManageGuestPasses"
 			command="ManageGuestPasses"
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		Settings {
 			text="#steam_menu_settings"
 			command="Settings"
 		}
-		
-		GoOnline {  
-			text="#SteamUI_OfflineMode_GoOnline"        
-			command="goonline" 
+
+		GoOnline {
+			text="#SteamUI_OfflineMode_GoOnline"
+			command="goonline"
 		}
 		GoOffline {
 			text="#SteamUI_OfflineMode_GoOffline"
-			command="gooffline" 
+			command="gooffline"
 		}
-		
+
 		Restart {
 			text="#Steam_MustRestart_Button"
 			command="RestartSteam"
 		}
-		
+
 		Exit {
 			text="#Steam_ExitSteam"
 			command="Exit"
-		}   
+		}
 	}
-	
+
 	Store [$OSX] {
 		text="#steam_store"
 
@@ -181,12 +183,12 @@
 
 	Library [$OSX] {
 		text="#steam_library"
-		
+
 		Games {
 			text="#steam_menu_view_games"
 			shellcmd="steam://nav/games"
 		}
-		
+
 		GamesDetails {
 			text="#steam_menu_games_details"
 			shellcmd="steam://nav/games/details"
@@ -203,12 +205,12 @@
 		}
 
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		MusicDetails {
 			text="#steam_menu_view_music_details"
 			shellcmd="steam://nav/music/details"
 		}
-		
+
 		MusicPlayer {
 			text="#steam_menu_view_musicplayer"
 			shellcmd="steam://open/musicplayer"
@@ -227,7 +229,7 @@
 		}
 
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		BackupGames {
 			text="#steam_menu_backupgames"
 			command="backupgames"
@@ -264,10 +266,10 @@
 
 		Broadcasts {
 			text="#steam_subnav_broadcast"
-			shellcmd="steam://openurl/http://steamcommunity.com/?subsection=broadcasts"
+			shellcmd="steam://url/GameHubBroadcasts"
 		}
 	}
-	
+
 	Friends [$OSX] {
 		text="#steam_menu_friends_view"
 
@@ -277,7 +279,7 @@
 		}
 
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		ViewFriends {
 			text="#steam_menu_view_friends"
 			shellcmd="steam://open/friends"
@@ -289,63 +291,63 @@
 		}
 
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		Online {
 			text="#friends_online"
 			shellcmd="steam://friends/status/online"
 			checkable=1
 		}
-		
+
 		Away {
 			text="#friends_away"
 			shellcmd="steam://friends/status/away"
 			checkable=1
 		}
-		
+
 		Play {
 			text="#friends_lookingtoplay"
 			shellcmd="steam://friends/status/play"
 			checkable=1
 		}
-		
+
 		Trade {
 			text="#friends_lookingtotrade"
 			shellcmd="steam://friends/status/trade"
 			checkable=1
 		}
-		
+
 		Busy {
 			text="#friends_busy"
 			shellcmd="steam://friends/status/busy"
 			checkable=1
 		}
-		
+
 		Offline  {
 			text="#friends_offline"
 			shellcmd="steam://friends/status/offline"
 			checkable=1
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		SortByName  {
 			text="#steam_menu_friends_sortbyname"
 			shellcmd="steam://friends/settings/sortbyname"
 			checkable=1
 		}
-		
+
 		ShowAvatars {
 			text="#steam_menu_friends_showavatars"
 			shellcmd="steam://friends/settings/showavatars"
 			checkable=1
 		}
-		
+
 		OnlineUsersOnly {
 			text="#steam_menu_friends_hideoffline"
 			shellcmd="steam://friends/settings/hideoffline"
 			checkable=1
 		}
-		
+
 		ShowTagged {
 			text="#steam_menu_friends_showtagged"
 			shellcmd="steam://friends/settings/showtagged"
@@ -354,15 +356,15 @@
 	}
 
 	Steam [$OSX] {
-		text = "Me" 
-		
+		text = "Me"
+
 		ViewProfile {
-			text="#steam_menu_account_view_profile" 
+			text="#steam_menu_account_view_profile"
 			shellcmd="steam://url/SteamIDMyProfile"
 		}
 
 		EditProfile {
-			text="Edit Profile..."                  
+			text="Edit Profile..."
 			shellcmd="steam://url/steam://url/SteamIDEditPage"
 		}
 
@@ -405,34 +407,34 @@
 		text="#steam_menu_view"
 
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		Inventory {
 			text="#steam_inventory"
 			shellcmd="steam://open/inventory"
 		}
-		
+
 		Screenshots {
 			text="#steam_screenshots"
 			command="Screenshots"
 		}
-		
+
 		ViewPlayerList {
 			text="#steam_menu_view_players"
-			shellcmd="steam://openurl/http://steamcommunity.com/my/friends/coplay"
+			shellcmd="steam://url/RecentlyPlayedWith"
 		}
-		
+
 		Servers {
 			text="#steam_menu_servers"
 			shellcmd="steam://open/servers"
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		MiniMode {
 			text="#steam_menu_minimode"
 			shellcmd="steam://open/minigameslist"
 		}
-		
+
 		LargeMode {
 			text="#steam_menu_largemode"
 			shellcmd="steam://open/largegameslist"
@@ -443,7 +445,7 @@
 		text="#steam_menu_window"
 
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		StartVR {
 			text="#steam_menu_startvr"
 			command="startvr"
@@ -452,51 +454,51 @@
 		BigPictureMode {
 			text="#steam_menu_bigpicturemode"
 			shellcmd="steam://open/bigpicture"
-		} 
+		}
 	}
-	
+
 	Help [$OSX] {
 		text="#steam_menu_help"
-		
+
 		Support {
 			text="#steam_menu_support"
 			command="Support"
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		Privacy {
 			text="#steam_menu_PrivacyPolicy"
 			shellcmd="steam://url/PrivacyPolicy"
 		}
-		
+
 		Legal {
 			text="#steam_menu_LegalInformation"
 			shellcmd="steam://url/LegalInformation"
 		}
-		
+
 		SSA {
 			text="#steam_menu_SteamSubscriberAgreement"
 			shellcmd="steam://url/SSA"
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		SystemInfo {
 			text="#steam_menu_systeminfo"
 			command="SystemInfo"
 		}
-		
+
 		About {
 			text="#steam_about"
 			command="About"
 		}
-		
+
 		Divider {} // ________________________________________________________________________________________________________________________
-		
+
 		SkinVersion {
 			text="Pressure BETA"
-			shellcmd="steam://openurl/http://steamcommunity.com/groups/pressureskin"
+			shellcmd="steam://url/GroupSteamIDPage/103582791435510416"
 		}
 	}
 }


### PR DESCRIPTION
See Steam/public/url_list.txt for more useful URLs.
Divider under "Small Mode"/"Large Mode" would never show up if "Large
Mode" button didn't exist.