### PR TITLE
Reduce bottom margin of nonsteam game details

### DIFF
--- a/resource/layout/gamespage_details_nonsteam.layout
+++ b/resource/layout/gamespage_details_nonsteam.layout
@@ -6,7 +6,7 @@
 	}
 
 	styles {
-		nonsteamdetails { 
+		nonsteamdetails {
 			bgcolor=black65
 			minimum-height=120
 		}
@@ -25,24 +25,25 @@
 	}
 
 	layout {
-		region { 
-			name=body 
+		region {
+			name=body
 			width=max
 			height=max
-			margin=20 
+			margin=20
+			margin-bottom=5
 		}
-		
-		place { 
-			control=headerlabel 
-			region=body 
-			width=max 
+
+		place {
+			control=headerlabel
+			region=body
+			width=max
 		}
-		
-		place { 
+
+		place {
 			control=bodycontent
 			region=body
-			y=35 
+			y=35
 			width=max
-		}		
+		}
 	}
 }


### PR DESCRIPTION
Fixes #310
Allows for up to 3 lines of text there.

Ideally the area itself would expand with more text, but I don't think that can be done.