### PR TITLE
Fix for music page links under album art

### DIFF
--- a/resource/layout/musicpage_details_album.layout
+++ b/resource/layout/musicpage_details_album.layout
@@ -2,7 +2,7 @@
 	styles {
 		CMusicPage_Details_Album {
 			bgcolor=none
-			//minimum-height=500
+			minimum-height=300
 		
 			render {}
 			render_bg {}


### PR DESCRIPTION
Added minimum-height back so links under album art are not cut off when there are few songs are in the list.