### PR TITLE
Fix music settings folder list

### DIFF
--- a/resource/layout/settingssubmusic.layout
+++ b/resource/layout/settingssubmusic.layout
@@ -8,6 +8,7 @@
 			font-weight=400
 			font-style="regular,normal"
 			inset= "0 0 0 0"
+			minimum-height=0
 
 			render {}
 			render_bg {}


### PR DESCRIPTION
Add minimum-height=0 in ListPanelColumnheader so that the top-most folder in the list is clickable.