### PR TITLE
Updates to FriendsDialog, friendpanels, group chat titles, friend chat titles, PageTabs, games grid, etc.

### DIFF
--- a/friends/ChatRoomDlgFriend.res
+++ b/friends/ChatRoomDlgFriend.res
@@ -335,7 +335,7 @@
 
 		place {
 			control="TitlePanel"
-			x=6
+			x=5
 			y=7
 			width=max
 			height=52

--- a/friends/FriendsDialog.res
+++ b/friends/FriendsDialog.res
@@ -1,12 +1,16 @@
 "Friends/FriendsDialog.res" {
+	colors {
+		PropertySheet.TabGap 1
+	}
 	styles {
 		// Here we force-set the minimum width to ensure that the search bar is not cut off.
 		CFriendsDialog {
 			font-family=basefont
 			font-style="normal"
-			minimum-width=225
+			minimum-width=224
 			minimum-height=400
 		}
+
 		FrameTitle {
 			bgcolor=none
 			textcolor=none
@@ -61,13 +65,15 @@
 					11="fill(x0+1, y0+144, x1-1, y0+230, darkestGrey)" // Single pixel line below the gradient
 				}
 			}
+
 		// Used to push the friends section down lower for trickery with the PageTabs.
 		Page {
 			bgcolor=none
 			font-family=basefont
 			font-style="none"
-			inset="0 10 0 0"
+			inset="0 5 0 0"
 		}
+
 		SectionedlistpanelCollapser {
 			font-family=basefont
 			font-style="normal"
@@ -77,6 +83,7 @@
 			minimum-height=14
 			render_bg {}
 		}
+
 		// Overriding the default styling for these controls.
 		// So far, can't work out a way to move the pagetabs higher from their current position to make the button look.
 		PageTab {
@@ -86,38 +93,40 @@
 			font-outerglow-color="darkGreyEnd"
 			font-outerglow-offset=1
 			font-outerglow-filtersize=1
-			inset="7 -7 0 0"
+			inset="7 -2 0 0"
 			minimum-width=101
-			minimum-height=34
+			minimum-height=26
 			render_bg {
-				1="gradient(x0+10, y0+3, x1+12, y1-9, grey, lightGreyEnd)"
-				2="fill(x0+10, y0+3, x1+12, y0+4, greyHighlight)"
-				3="fill(x0+10, y0+3, x0+11, y0+4, darkGreyEnd)"
-				4="fill(x1+11, y0+3, x1+12, y0+4, darkGreyEnd)"
-				7="fill(x0+10, y1-10, x0+11, y1-9, darkGrey)"
-				8="fill(x1+11, y1-10, x1+12, y1-9, darkGrey)"
+				1="gradient(x0+10, y0+2, x1+12, y1-2, grey, lightGreyEnd)"
+				2="fill(x0+10, y0+2, x1+12, y0+3, greyHighlight)"
+				3="fill(x0+10, y0+2, x0+11, y0+3, darkGreyEnd)"
+				4="fill(x1+11, y0+2, x1+12, y0+3, darkGreyEnd)"
+				7="fill(x0+10, y1-3, x0+11, y1-2, darkGrey)"
+				8="fill(x1+11, y1-3, x1+12, y1-2, darkGrey)"
 			}
 		}
 			PageTab:hover {
 				textcolor=white
 				render_bg {
-					0="gradient(x0+10, y0+3, x1+12, y1-9, greyHighlight, grey)"
-					1="fill(x0+10, y0+3, x1+12, y0+4, lightestGreyHighlight)"
-					3="fill(x0+10, y0+3, x0+11, y0+4, darkGreyEnd)"
-					4="fill(x1+11, y0+3, x1+12, y0+4, darkGreyEnd)"
-					7="fill(x0+10, y1-10, x0+11, y1-9, darkGrey)"
-					8="fill(x1+11, y1-10, x1+12, y1-9, darkGrey)"
+					0="gradient(x0+10, y0+2, x1+12, y1-2, greyHighlight, grey)"
+					1="fill(x0+10, y0+2, x1+12, y0+3, lightestGreyHighlight)"
+					3="fill(x0+10, y0+2, x0+11, y0+3, darkGreyEnd)"
+					4="fill(x1+11, y0+2, x1+12, y0+3, darkGreyEnd)"
+					7="fill(x0+10, y1-3, x0+11, y1-2, darkGrey)"
+					8="fill(x1+11, y1-3, x1+12, y1-2, darkGrey)"
 				}
 			}
 			PageTab:selected {
 				textcolor=blue
 				render_bg {}
 			}
+
 		"CFriendsDialog SectionedListPanel" {
 		    bgcolor=none
 		    font-family=basefont
 		    render_bg {}
 	    }
+
 	    CFriendsListSectionHeader {
 			textcolor=white
 			font-family=semibold
@@ -129,6 +138,7 @@
 				2="gradient(x0-22,y1,x1,y1+1, darkGrey, none)"
 			}
 	    }
+
 		// The actual whole dialog window itself.
 		FriendsPanel {
 			bgcolor="darkestGrey"
@@ -141,6 +151,7 @@
 				3="gradient( x0+1, y1-14, x1-1, y1-1, grey, lightGreyEnd )"
 			}
 		}
+
 		AddFriendsButton  {
 			textcolor="none"
 			font-family=basefont
@@ -154,10 +165,12 @@ font-size=14 [$LINUX]
 				textcolor="none"
 				render_bg {}
 			}
+
 		RootMenu {
 			bgcolor="none"
 			textcolor="none"
 		}
+
 		// Hide the word "Friends" on the title area.
 		FriendsTitle [$OSX] {
 			bgcolor=none
@@ -173,6 +186,7 @@ font-size=14 [$LINUX]
 				font-size=1
 				font-weight=400
 			}
+
 		"MenuBar MenuButton" {
 			textcolor=none
 			render_bg {
@@ -191,6 +205,7 @@ font-size=14 [$LINUX]
 					0="image( x0, y0, x1,y1, graphics/supermenus/friends/active )"
 				}
 			}
+
 		FriendsSearch {
 			textcolor="darkestGrey"
 			font-family=basefont
@@ -201,20 +216,22 @@ font-size=14 [$LINUX]
 			padding-right=20
 			inset-left=0
 			minimum-width=110
-				render {
-						0="fill(x0-27,y0+64,x1+9999,y0+65, darkestGrey)"
-				}
+			render {
+				0="fill(x0-27,y0+59,x1+9999,y0+60, darkestGrey)"
+			}
 			render_bg {
-				6="fill(x0-27, y0-5, x1+9999, y0+64, lightGreyEnd)"
+				6="fill(x0-27, y0-5, x1+9999, y0+59, lightGreyEnd)"
 				1="image(x0-19, y0, x0+3, y0+25, graphics/search/active/left)"
 				2="image(x1-14, y0, x1-2, y0+25, graphics/search/active/right)"
 				3="image_scale(x0+3, y0, x1-14, y0+25, graphics/search/active/inner)"
-				15="fill(x0-19,y0+32,x0+187,y0+56, darkestGrey)"// Top->Bottom
-				16="fill(x0-20,y0+33,x0-19,y0+55, darkestGrey)" // Left
-				17="fill(x0+187,y0+33,x0+188,y0+55, darkestGrey)" // Right
-				18="fill(x0-19,y0+56,x0+187,y0+57, grey50)"//grey50)"
-				19="fill(x0-20, y0+55, x0-19, y0+56, grey50)"
-				20="fill(x0+187, y0+55, x0+188, y0+56, grey50)"
+
+				//begin pagetab background
+				15="fill(x0-19,y0+31,x0+187,y0+55, darkestGrey)" //middle, top to bottom
+				16="fill(x0-20,y0+32,x0-19,y0+54, darkestGrey)" //left edge
+				17="fill(x0+187,y0+32,x0+188,y0+54, darkestGrey)" //right edge
+				18="fill(x0-19,y0+55,x0+187,y0+56, grey50)" //bottom highlight
+				19="fill(x0-20, y0+54, x0-19, y0+55, grey50)" //bottom left highlight
+				20="fill(x0+187, y0+54, x0+188, y0+55, grey50)" //bottom right highlight
 			}
 		}
 			// Typed in, as well as hovered.
@@ -224,19 +241,21 @@ font-size=14 [$LINUX]
 			}
 				FriendsSearch:focus {
 					render {
-						0="fill(x0-27,y0+64,x1+9999,y0+65, darkestGrey)"
+						0="fill(x0-27,y0+59,x1+9999,y0+60, darkestGrey)"
 					}
 					render_bg {
-						6="fill(x0-27, y0-5, x1+9999, y0+64, lightGreyEnd)"
+						6="fill(x0-27, y0-5, x1+9999, y0+59, lightGreyEnd)"
 						1="image(x0-19, y0, x0+3, y0+25, graphics/search/active/left)"
 						2="image(x1-14, y0, x1-2, y0+25, graphics/search/active/right)"
 						3="image_scale(x0+3, y0, x1-14, y0+25, graphics/search/active/inner)"
-						15="fill(x0-19,y0+32,x0+187,y0+56, darkestGrey)"// Top->Bottom
-						16="fill(x0-20,y0+33,x0-19,y0+55, darkestGrey)" // Left
-						17="fill(x0+187,y0+33,x0+188,y0+55, darkestGrey)" // Right
-						18="fill(x0-19,y0+56,x0+187,y0+57, grey50)"//grey50)"
-						19="fill(x0-20, y0+55, x0-19, y0+56, grey50)"
-						20="fill(x0+187, y0+55, x0+188, y0+56, grey50)"
+
+						//begin pagetab background
+						15="fill(x0-19,y0+31,x0+187,y0+55, darkestGrey)" //middle, top to bottom
+						16="fill(x0-20,y0+32,x0-19,y0+54, darkestGrey)" //left edge
+						17="fill(x0+187,y0+32,x0+188,y0+54, darkestGrey)" //right edge
+						18="fill(x0-19,y0+55,x0+187,y0+56, grey50)" //bottom highlight
+						19="fill(x0-20, y0+54, x0-19, y0+55, grey50)" //bottom left highlight
+						20="fill(x0+187, y0+54, x0+188, y0+55, grey50)" //bottom right highlight
 					}
 				}
 
@@ -262,54 +281,60 @@ font-size=14 [$LINUX]
 				padding-left=4
 
 				render {
-						0="fill(x0-27,y0+64,x1+9999,y0+65, darkestGrey)"
+					0="fill(x0-27,y0+59,x1+9999,y0+60, darkestGrey)"
 				}
 
 				render_bg {
-					6="fill(x0-27, y0-5, x1+9999, y0+64, lightGreyEnd)"
+					6="fill(x0-27, y0-5, x1+9999, y0+59, lightGreyEnd)"
 					1="image(x0-19, y0, x0+3, y0+25, graphics/search/left)"
 					2="image(x1-14, y0, x1-2, y0+25, graphics/search/right)"
 					3="image_scale(x0+3, y0, x1-14, y0+25, graphics/search/inner)"
-					15="fill(x0-19,y0+32,x0+187,y0+56, darkestGrey)"// Top->Bottom
-					16="fill(x0-20,y0+33,x0-19,y0+55, darkestGrey)" // Left
-					17="fill(x0+187,y0+33,x0+188,y0+55, darkestGrey)" // Right
-					18="fill(x0-19,y0+56,x0+187,y0+57, grey50)"//grey50)"
-					19="fill(x0-20, y0+55, x0-19, y0+56, grey50)"
-					20="fill(x0+187, y0+55, x0+188, y0+56, grey50)"
+
+					//begin pagetab background
+					15="fill(x0-19,y0+31,x0+187,y0+55, darkestGrey)" //middle, top to bottom
+					16="fill(x0-20,y0+32,x0-19,y0+54, darkestGrey)" //left edge
+					17="fill(x0+187,y0+32,x0+188,y0+54, darkestGrey)" //right edge
+					18="fill(x0-19,y0+55,x0+187,y0+56, grey50)" //bottom highlight
+					19="fill(x0-20, y0+54, x0-19, y0+55, grey50)" //bottom left highlight
+					20="fill(x0+187, y0+54, x0+188, y0+55, grey50)" //bottom right highlight
 				}
 			}
 				FriendsSearch:empty:focus [!$OSX] {
 					render {
-							0="fill(x0-27,y0+64,x1+9999,y0+65, darkestGrey)"
+						0="fill(x0-27,y0+59,x1+9999,y0+60, darkestGrey)"
 					}
 					render_bg {
-						6="fill(x0-27, y0-5, x1+9999, y0+64, lightGreyEnd)"
+						6="fill(x0-27, y0-5, x1+9999, y0+59, lightGreyEnd)"
 						1="image(x0-19, y0, x0+3, y0+25, graphics/search/active/left)"
 						2="image(x1-14, y0, x1-2, y0+25, graphics/search/active/right)"
 						3="image_scale(x0+3, y0, x1-14, y0+25, graphics/search/active/inner)"
-						15="fill(x0-19,y0+32,x0+187,y0+56, darkestGrey)"// Top->Bottom
-						16="fill(x0-20,y0+33,x0-19,y0+55, darkestGrey)" // Left
-						17="fill(x0+187,y0+33,x0+188,y0+55, darkestGrey)" // Right
-						18="fill(x0-19,y0+56,x0+187,y0+57, grey50)"//grey50)"
-						19="fill(x0-20, y0+55, x0-19, y0+56, grey50)"
-						20="fill(x0+187, y0+55, x0+188, y0+56, grey50)"
+
+						//begin pagetab background
+						15="fill(x0-19,y0+31,x0+187,y0+55, darkestGrey)" //middle, top to bottom
+						16="fill(x0-20,y0+32,x0-19,y0+54, darkestGrey)" //left edge
+						17="fill(x0+187,y0+32,x0+188,y0+54, darkestGrey)" //right edge
+						18="fill(x0-19,y0+55,x0+187,y0+56, grey50)" //bottom highlight
+						19="fill(x0-20, y0+54, x0-19, y0+55, grey50)" //bottom left highlight
+						20="fill(x0+187, y0+54, x0+188, y0+55, grey50)" //bottom right highlight
 					}
 				}
 				FriendsSearch:empty:active [!$OSX] {
 					render {
-							0="fill(x0-27,y0+64,x1+9999,y0+65, darkestGrey)"
+						0="fill(x0-27,y0+59,x1+9999,y0+60, darkestGrey)"
 					}
 					render_bg {
-						6="fill(x0-27, y0-5, x1+9999, y0+64, lightGreyEnd)"
+						6="fill(x0-27, y0-5, x1+9999, y0+59, lightGreyEnd)"
 						1="image(x0-19, y0, x0+3, y0+25, graphics/search/active/left)"
 						2="image(x1-14, y0, x1-2, y0+25, graphics/search/active/right)"
 						3="image_scale(x0+3, y0, x1-14, y0+25, graphics/search/active/inner)"
-						15="fill(x0-19,y0+32,x0+187,y0+56, darkestGrey)"// Top->Bottom
-						16="fill(x0-20,y0+33,x0-19,y0+55, darkestGrey)" // Left
-						17="fill(x0+187,y0+33,x0+188,y0+55, darkestGrey)" // Right
-						18="fill(x0-19,y0+56,x0+187,y0+57, grey50)"//grey50)"
-						19="fill(x0-20, y0+55, x0-19, y0+56, grey50)"
-						20="fill(x0+187, y0+55, x0+188, y0+56, grey50)"
+
+						//begin pagetab background
+						15="fill(x0-19,y0+31,x0+187,y0+55, darkestGrey)" //middle, top to bottom
+						16="fill(x0-20,y0+32,x0-19,y0+54, darkestGrey)" //left edge
+						17="fill(x0+187,y0+32,x0+188,y0+54, darkestGrey)" //right edge
+						18="fill(x0-19,y0+55,x0+187,y0+56, grey50)" //bottom highlight
+						19="fill(x0-20, y0+54, x0-19, y0+55, grey50)" //bottom left highlight
+						20="fill(x0+187, y0+54, x0+188, y0+55, grey50)" //bottom right highlight
 					}
 				}
 				FriendsSearch:empty:focus [$OSX] {
@@ -354,6 +379,7 @@ font-size=14 [$LINUX]
 				font-style=italic
 				padding-left=0
 			}
+
 		// Used as an overlay to round off the buttons
 		FriendsSearchIcon {
 			bgcolor="none"
@@ -410,6 +436,7 @@ font-size=14 [$LINUX]
 			width=max
 			height=0
 		}
+
  		// the title bar is missing, so increase the size of the grip
 		place {
 			control="frame_captiongrip"
@@ -417,6 +444,7 @@ font-size=14 [$LINUX]
 			height=50
 			margin=2
 		}
+
 		place [!$OSX] {
 			control="MenuBar"
 			margin-left=2
@@ -424,12 +452,15 @@ font-size=14 [$LINUX]
 			height=24
 			margin-top=-1
 		}
+
 		place {
 			control="FriendPanelSelf"
 			x=10
 			y=25
 			width=max
+			margin-right=4
 		}
+
 		place {
 			control="friends_search"
 			start="FriendPanelSelf"
@@ -441,6 +472,7 @@ font-size=14 [$LINUX]
 			margin-top=1
 			dir=down
 		}
+
 		place {
 			control="FriendsDialogSheet"
 			align=left
@@ -453,6 +485,7 @@ font-size=14 [$LINUX]
 			margin-right=0
 			margin-bottom=16
 		}
+
 		// Use this for cleverness to make the buttons.
 		place {
 			control="friends_search_icon" // this rounds off the corners for the pagetab buttons; it was never clickable
@@ -462,6 +495,7 @@ font-size=14 [$LINUX]
 			height=0
 			dir=right
 		}
+
 		place {
 			control="addFriendsButton" // this rounds off the corners for the pagetab buttons; it's still clickable
 			width=0
@@ -470,6 +504,7 @@ font-size=14 [$LINUX]
 			margin-left=145
 			dir=right
 		}
+
 		place {
 			control="NoFriendsAddFriendButton"
 			width=141
@@ -477,6 +512,7 @@ font-size=14 [$LINUX]
 			margin-left=6
 			margin-top=83
 		}
+
 		place {
 			control="DownLabel"
 			width=max

--- a/includes/controls.styles
+++ b/includes/controls.styles
@@ -29,8 +29,8 @@
 	  TabCloseButton {
 		render_bg {}
 
-		inset="-4 3 0 0" [$OSX]
-		inset="-7 3 0 0"  // Adjusted for windows to match screenshots
+		inset="-9 2 0 0" [$OSX]
+		inset="-12 2 0 0"  // Adjusted for windows to match screenshots
 		image  = "graphics/tab_close"
     }
 		TabCloseButton:hover {

--- a/includes/settings.styles
+++ b/includes/settings.styles
@@ -36,7 +36,7 @@
 		Menu.TextInset "6"
 
 		PropertySheet.TransitionEffectTime "0"	 // time to change from one tab to another
-		PropertySheet.TabGap 1
+		PropertySheet.TabGap -2
 		PropertySheet.FlashTabColor "255 114 76 255"
 
 		SectionedListPanel.CollapserWidth 10

--- a/includes/tweaks/grid/not-transparent.styles
+++ b/includes/tweaks/grid/not-transparent.styles
@@ -6,5 +6,8 @@
 		"GameItem_Uninstalled GamesGridImage" {
 			alpha 255
 		}
+		"GameItem_Uninstalled GamesGridIcon" {
+			alpha 255
+		}
 	}
 }

--- a/includes/tweaks/grid/transparent.styles
+++ b/includes/tweaks/grid/transparent.styles
@@ -6,5 +6,8 @@
 		"GameItem_Uninstalled GamesGridImage" {
 			alpha 75
 		}
+		"GameItem_Uninstalled GamesGridIcon" {
+			alpha 75
+		}
 	}
 }

--- a/resource/layout/chattitlepanel.layout
+++ b/resource/layout/chattitlepanel.layout
@@ -1,22 +1,22 @@
 "resource/layout/chattitlepanel.layout" {
 	styles {
 		menuButtonStyle {
-			minimum-width=10
 			padding-top=6
 			padding-bottom=4
 			padding-right=5
-			padding-left=3
+			padding-left=2
+			minimum-width=10
+			inset-top=-2
 		}
-
-		menuButtonStyle:hover {
-			render_bg {}
-		}
+			menuButtonStyle:hover {
+				render_bg {}
+			}
 
 		Label {
 			font-family=basefont
-			font-size=15
-			font-size=14 [$LINUX]
-			font-weight=500
+			font-size=16
+font-size=15 [$LINUX]
+			font-weight=600
 			textcolor=white
 
 			font-style="outerglow"
@@ -29,6 +29,7 @@
 			font-family=basefont
 			textcolor=lightestGrey
 			font-size=15
+font-size=14 [$LINUX]
 
 			font-style="normal,regular,outerglow"
 			font-outerglow-color="darkestGrey"
@@ -42,39 +43,36 @@
 		place {
 			control="AvatarImage"
 			x=1
-			y=5
+			y=4
 			align=left
 			dir=right
 			spacing=8
 		}
 
 		place {
-			control="NameLabel"
-			x=62
-			y=8
-			align=left
-			dir=right
-			spacing=0
+			control="LockImage"
+			width=10
+			height=20
 		}
+		place {
+			control="LockImage,NameLabel"
+			x=46
+			y=2
+			spacing=2
+		}
+
 		place {
 			control=MenuButton
 			start=NameLabel
 			x=2
-			y=-4
-		}
-
-		place {
-			control="LockImage"
-			x=44
-			y=10
-			width=16
+			y=-3
 		}
 
 		place {
 			control="StatusLabel"
 			align=left
-			x=47
-			y=26
+			x=46
+			y=30
 		}
 	}
 }

--- a/resource/layout/friendpanel.layout
+++ b/resource/layout/friendpanel.layout
@@ -6,13 +6,15 @@
 		CFriendPanel:selected {
 			render_bg {}
 		}
+
 		SelfPanel:hover {
 			render_bg {}
 		}
+
 		namestyle {
 			font-family=basefont
 			font-size=16
-font-size=14 [$LINUX]
+font-size=15 [$LINUX]
 			font-weight=600
 			inset-top=-1
 			//font-style="outerglow"
@@ -26,22 +28,25 @@ font-size=14 [$LINUX]
 				// font-outline-offset=1
 				// font-outline-filtersize=3
 			// }
+
 		nameInstanceStyle {
 			textcolor="lightestGrey"
 			font-family=basefont
 			font-size=14
 		}
+
 		menuButtonStyle {
-			padding-top=6
-			padding-bottom=4
+			minimum-width=14
+			padding-top=5
+			padding-bottom=2
 			padding-right=5
-			padding-left=2
-			minimum-width=10
-			inset-top=-2
+			padding-left=1
+			inset-top=-3
 		}
 			menuButtonStyle:hover {
 				render_bg {}
 			}
+
 		controlPanelLinkStyle {
 			font-family=basefont
 			font-size=15
@@ -52,11 +57,13 @@ font-size=14 [$LINUX]
 				font-size=15
 font-size=14 [$LINUX]
 			}
+
 		statusStyle {
 			font-family=basefont
 			font-size=15
 font-size=14 [$LINUX]
 		}
+
 		inviteLinkStyle {
 			textcolor=blue
 			font-style=normal
@@ -65,18 +72,9 @@ font-size=14 [$LINUX]
 				textcolor=lightestBlue
 				font-style=underline
 			}
+
 		WebStatusStyle {
 			image="graphics/icon_status_web"
-			padding-left=2
-			inset-top=2
-		}
-		BigPictureStatusStyle {
-			image="graphics/icon_status_bigpic"
-			padding-left=2
-			inset-top=2
-		}
-		MobileStatusStyle {
-			image="graphics/icon_status_mobile"
 			padding-left=2
 			inset-top=2
 		}
@@ -85,8 +83,20 @@ font-size=14 [$LINUX]
 			padding-left=2
 			inset-top=2
 		}
+
+		BigPictureStatusStyle {
+			image="graphics/icon_status_bigpic"
+			padding-left=2
+			inset-top=2
+		}
 		BigPictureStatusStyleInGame {
 			image="graphics/icon_status_bigpic_ingame"
+			padding-left=2
+			inset-top=2
+		}
+
+		MobileStatusStyle {
+			image="graphics/icon_status_mobile"
 			padding-left=2
 			inset-top=2
 		}
@@ -99,50 +109,52 @@ font-size=14 [$LINUX]
 	layout {
 		place {
 			control="AvatarOverlayImage"
-			x=0
+			x=1
 			y=4
 			width=40
 			height=40
 		}
+
 		place {
 			control="AvatarImage"
-			x=4
+			x=5
 			y=8
 			width=32
 			height=32
 		}
+
 		place {
 			control="ClanStatusImage"
 			width=10
-			height=18
+			height=16
 		}
 		place [$OSX] {
-			control="ClanStatusImage,NameLabel,FriendsNameInstanceLabel"
-			x=46
+			control="ClanStatusImage,NameLabel,FriendsNameInstanceLabel,MenuButton"
+			x=45
 			y=5
+			spacing=2
+			margin-right=3
 		}
 		place [!$OSX] {
-			control="ClanStatusImage,NameLabel,FriendsNameInstanceLabel"
-			x=46
+			control="ClanStatusImage,NameLabel,FriendsNameInstanceLabel,MenuButton"
+			x=45
 			y=2
 			spacing=2
+			margin-right=3
 		}
-		place {
-			control=MenuButton
-			start=FriendsNameInstanceLabel
-			x=2
-			y=-3
-		}
+
 		place {
 			control="StatusLabel"
-			x=46
+			x=45
 			y=16
 		}
+
 		place {
 			control="GameLabel"
-			x=46
+			x=45
 			y=30
 		}
+
 		place {
 			control="BigPictureStatusImage,MobileStatusImage,WebStatusImage,BigPictureStatusImageInGame,MobileStatusImageInGame,WebStatusImageInGame"
 			start="StatusLabel"
@@ -153,8 +165,8 @@ font-size=14 [$LINUX]
 		// these controls are shown for friendship requests
 		place {
 			control="AcceptLink,IgnoreLink,BlockLink"
-			x=46
-			y=27
+			x=45
+			y=31
 			spacing=10
 		}
 		// this control is shown in the invite-to-game dialog in the overlay
@@ -164,20 +176,23 @@ font-size=14 [$LINUX]
 			y=4
 			margin-right=20
 		}
+
 		place {
 			control="ControlPanelLink"
-			x=46
-			y=27
+			x=45
+			y=31
 		}
+
 		place {
 			control="SuggestedImage,SuggestedLabel"
-			x=46
+			x=45
 			y=19
 			spacing=4
 		}
+
 		place {
 			control="SuggestedInvite,SuggestedIgnore"
-			x=46
+			x=45
 			y=31
 			spacing=8
 		}

--- a/resource/layout/friendpanel_compact.layout
+++ b/resource/layout/friendpanel_compact.layout
@@ -40,17 +40,18 @@ font-size=14 [$LINUX]
 			padding-top=5
 			padding-bottom=4
 			padding-right=5
-			padding-left=4
+			padding-left=1
 			inset-top=-2
 		}
-		menuButtonStyle:hover {
-			render_bg {}
-		}
-			downarrow:hover {
+			menuButtonStyle:hover {
+				render_bg {}
+			}
+			downarrow:hover {	//remove?
 				render_bg {
 					0="image( x0, y0, x1, y1, graphics/icon_down_hover )"
 				}
 			}
+
 		inviteLinkStyle {
 			textcolor=blue
 			font-style="normal"
@@ -67,6 +68,7 @@ font-size=14 [$LINUX]
 			x=0
 			y=2
 			spacing=3
+			margin-right=3
 		}
 	}
 }

--- a/resource/layout/gamespage_grid_chrome.layout
+++ b/resource/layout/gamespage_grid_chrome.layout
@@ -1,8 +1,17 @@
 "resource/layout/gamespage_grid_chrome.layout" {
 	styles {
 		ChromeBorderItem {
-			bgcolor= black75
+			bgcolor=none
+			render_bg {
+				0="gradient(x0, y0, x1, y0+13, none, black40)" //5 above the buttons
+				1="gradient(x0, y0+13, x1, y0+57, black40, black65)" //5 above to 5 below
+				2="gradient(x0, y0+57, x1, y1, black65, black90)" //5 below the buttons
+			}
 		}
+			"GameItem_Uninstalled ChromeBorderItem" {	//Does _notinstalled exist too?
+				bgcolor=black75
+			}
+
 		GridNavDivider {
 			bgcolor=none
 			textcolor=none
@@ -18,7 +27,7 @@
 			inset="22 7 0 0"
 
 			render {
-				1="image( x0 + 9, y0 + 12, x1, y1, graphics/gamedetails/install/install_icon )"
+				1="image( x0 + 9, y0 + 11, x1, y1, graphics/gamedetails/install/install_icon )"
 			}
 			render_bg {
 				// Background
@@ -72,7 +81,7 @@
 			inset="22 3 0 0"
 
 			render {
-				1="image( x0 + 9, y0 + 12, x1, y1, graphics/gamedetails/install/install_icon )"
+				1="image( x0 + 9, y0 + 11, x1, y1, graphics/gamedetails/install/install_icon )"
 			}
 			render_bg {
 				// Background
@@ -248,10 +257,10 @@
 			font-style="none"
 			padding-right=10
 			padding-left=10
-			inset="22 7 0 0"
+			inset="20 7 0 0"
 
 			render {
-				1="image( x0 + 10, y0 + 7, x1, y1, graphics/gamedetails/play/play_icon )"
+				1="image( x0 + 8, y0 + 6, x1, y1, graphics/gamedetails/play/play_icon )"
 			}
 			render_bg {
 				// Background
@@ -302,10 +311,10 @@
 			font-outerglow-filtersize=6
 			padding-right=10
 			padding-left=10
-			inset="22 3 0 0"
+			inset="20 3 0 0"
 
 			render {
-				1="image( x0 + 10, y0 + 7, x1, y1, graphics/gamedetails/play/play_icon )"
+				1="image( x0 + 8, y0 + 6, x1, y1, graphics/gamedetails/play/play_icon )"
 			}
 			render_bg {
 				// Background
@@ -478,7 +487,7 @@
 			inset="22 7 0 0"
 
 			render {
-				1="image( x0 + 10, y0 + 10, x1, y1, graphics/gamedetails/details/details_icon )"
+				1="image( x0 + 10, y0 + 9, x1, y1, graphics/gamedetails/details/details_icon )"
 			}
 			render_bg {
 				// Background
@@ -528,7 +537,7 @@
 			inset="22 3 0 0"
 
 			render {
-				1="image( x0 + 10, y0 + 10, x1, y1, graphics/gamedetails/details/details_icon )"
+				1="image( x0 + 10, y0 + 9, x1, y1, graphics/gamedetails/details/details_icon )"
 			}
 			render_bg {
 				// Background
@@ -692,9 +701,10 @@
 		CUIDetailsButton:disabled {
 			image=graphics/details_d
 		}
-			"GameItem_Updating CUINavButton:hover" {
-				textcolor="White"
-			}
+
+		"GameItem_Updating CUINavButton:hover" {
+			textcolor="White"
+		}
 	}
 	layout {
 		region {
@@ -703,7 +713,7 @@
 			x=0
 			y=210
 			width=max
-			height=78
+			height=70
 			margin-bottom=0
 		}
 
@@ -721,11 +731,11 @@
 			control="launch,details"
 			region="actions"
 			align=top-center
-			height=40
+			height=34
 			margin-left=8
 			margin-top=18
 			margin-right=8
-			margin-bottom=24
+			margin-bottom=18
 			spacing=16
 		}
 

--- a/resource/layout/gamespage_grid_loadfailed.layout
+++ b/resource/layout/gamespage_grid_loadfailed.layout
@@ -15,6 +15,9 @@
 		GGPlaceholderBG {
 			bgcolor=none
 		}
+		"GameItem_Uninstalled GamesGridPlaceholder" {
+			textcolor=white20
+		}
 		"GameItem_installed GamesGridPlaceholder" {
 			textcolor="white"
 		}

--- a/resource/layout/htmlfindbar.layout
+++ b/resource/layout/htmlfindbar.layout
@@ -1,10 +1,11 @@
 "resource/layout/htmlfindbar.layout" {
 	styles {
 		FindEntry {
+			inset-left=0
 			render_bg{
 				1="image(x0-19, y0, x0+3, y0+25, graphics/search/left)"
-				2="image(x1-14, y0, x1-2, y0+25, graphics/search/right)"
-				3="image_tiled(x0+3, y0, x1-14, y0+25, graphics/search/inner)"
+				2="image(x1-8, y0, x1-2, y0+25, graphics/search/right)"
+				3="image_tiled(x0+3, y0, x1-8, y0+25, graphics/search/inner)"
 			}
 		}
 
@@ -14,7 +15,6 @@
 			image="graphics/tab_close"
 			render_bg{}
 		}
-
 			CloseButtonSm:hover {
 				image="graphics/tab_close_hover"
 				render_bg{}
@@ -26,7 +26,6 @@
 			image="graphics/icon_down_default"
 			render_bg{}
 		}
-
 			NextButtonSm:hover {
 				bgcolor=none
 				inset="0 0 0 0"
@@ -40,7 +39,6 @@
 			image="graphics/icon_up_default"
 			render_bg{}
 		}
-
 			PrevButtonSm:hover {
 				bgcolor=none
 				inset="0 0 0 0"

--- a/resource/layout/steamrootdialog.layout
+++ b/resource/layout/steamrootdialog.layout
@@ -412,6 +412,7 @@ font-size=14 [$LINUX]
 // ********************************************************************************************************
 		"MenuBar MenuButton" {
 			textcolor="none"
+			padding-right=1
 			render_bg {
 				0="image( x0, y0, x1,y1, graphics/supermenus/client/normal )"
 			}

--- a/resource/layout/toolwindow.layout
+++ b/resource/layout/toolwindow.layout
@@ -6,7 +6,7 @@
 		ToolWindow {
 			render_bg {
 				// Creates the top section
-				0="gradient( x0+1, y0+1, x1-1, y0 + 60, grey, lightGreyEnd )"
+				0="gradient( x0+1, y0+1, x1-1, y0 + 49, grey, lightGreyEnd )"
 				1="fill(x0+1, y0+1, x0+2, y0+2, bottomDarkPixels)" // Top Left Dark Pixel
 				2="fill(x1-2, y0+1, x1-1, y0+2, bottomDarkPixels)" // Top Right Dark Pixel
 				3="fill(x0+2, y0+1, x0+3, y0+2, greyHighlightFake)" // Top Left Fake Anti-Aliased
@@ -50,8 +50,10 @@
 			textcolor=yellow
 			render_bg {}
 		}
-		TabMenuButton {
+		TabMenuButton {	//doesn't actually exist?
 			inset-top=5
+			minimum-width=0
+			padding-right=0
 		}
 		TabMenuButtonFlash {
 			render {}
@@ -80,22 +82,22 @@ font-size=14 [$LINUX]
 			minimum-height=30
 			render_bg {
 				1="image(x0,y0,x0+3,y0+28,graphics/tabs/inactive/left)"
-				2="image(x1,y0,x1+3,y0+28, graphics/tabs/inactive/right)"
+				2="image(x1-3,y0,x1,y0+28, graphics/tabs/inactive/right)"
 				// Tiled images are tripled in height. Using y0+30 will cause the image to appear multiple times
-				3="image_scale(x0+3,y0,x1,y1-2, graphics/tabs/inactive/inner)"
+				3="image_scale(x0+3,y0,x1-3,y1-2, graphics/tabs/inactive/inner)"
 			}
 		}
 		PageTab:selected {
 			textcolor=white
 			render_bg {
-				0="fill(x0+1,y0+27,x1-1,y0+30, grey)" // Overlaps the highlight
-				1="fill(x0+1, y0+1, x1+2, y1, grey)"
-				2="fill(x1+1, y0+30,x1+2, y0+31, greyHighlight)"
+				0="fill(x0+1,y0+27, x1-1, y0+30, grey)" // Overlaps the highlight
+				1="fill(x0+1, y0+1, x1-1, y1, grey)"
+				2="fill(x1-2,y0+30, x1-1, y0+31, greyHighlight)"
 				3="image(x0,y0,x0+3,y0+30,graphics/tabs/active/left)"
-				4="image(x1,y0,x1+3,y0+30, graphics/tabs/active/right)"
+				4="image(x1-3,y0,x1,y0+30, graphics/tabs/active/right)"
 				// Tiled images are tripled in height. Using y0+30 will cause the image to appear multiple times
-				5="image_scale(x0+3,y0,x1,y1, graphics/tabs/active/inner)"
-				6="fill(x0, y1, x1+2, y1+1, Grey)" //Fix for Ingame Web Browser - No visual change anywhere else
+				5="image_scale(x0+3,y0,x1-3,y1, graphics/tabs/active/inner)"
+				6="fill(x0, y1, x1-1, y1+1, Grey)" //Fix for Ingame Web Browser - No visual change anywhere else
 			}
 		}
 	}

--- a/resource/menus/steam.menu
+++ b/resource/menus/steam.menu
@@ -228,31 +228,37 @@
 			text="#friends_online"
 			shellcmd="steam://friends/status/online"
 			checkable=1
+			autocheck=0
 		}
 		Away {
 			text="#friends_away"
 			shellcmd="steam://friends/status/away"
 			checkable=1
+			autocheck=0
 		}
 		Play {
 			text="#friends_lookingtoplay"
 			shellcmd="steam://friends/status/play"
 			checkable=1
+			autocheck=0
 		}
 		Trade {
 			text="#friends_lookingtotrade"
 			shellcmd="steam://friends/status/trade"
 			checkable=1
+			autocheck=0
 		}
 		Busy {
 			text="#friends_busy"
 			shellcmd="steam://friends/status/busy"
 			checkable=1
+			autocheck=0
 		}
 		Offline  {
 			text="#friends_offline"
 			shellcmd="steam://friends/status/offline"
 			checkable=1
+			autocheck=0
 		}
 		Divider {} // ________________________________________________________________________________________________________________________
 		SortByName  {


### PR DESCRIPTION
Also changes padding on main Steam menu button to match the button's visuals. I think I forgot that in the commit notes.

FriendsDialog no longer cuts off the last group/friend panel.

Users with long names are now able to see the FriendPanel menu button

Vertically centered ClanStatusImage.

Group chat title panel matches FriendPanel styling.

See commits for any more stuff.
