### PR TITLE
Updated spacing/text for download panels

### DIFF
--- a/resource/layout/appdownloadpanel.layout
+++ b/resource/layout/appdownloadpanel.layout
@@ -8,89 +8,98 @@
 				1="fill(x0,y0+1,x1,y0+8, lightGreyEnd)"
 				2="fill(x0,y0+1,x1,y0+2, grey25)"
 			}
+
 			render_bg {
 				1="gradient(x0,y1,x1,y1+6, black40, none)"
 				2="fill(x0,y0,x1,y1, lightGreyEnd)"
 				3="fill(x0,y0,x1,y0+1, greyHighlight)"
 			}
 		}
+
 		panelStyleHighlight {
 			render_bg {
 				0="fill(x0,y0,x1,y1+10, black65)"
 			}
 		}
+
 		links {
 			textcolor="blue"
 			font-family=basefont
 			font-size=15
-			font-size=14 [$LINUX]
+font-size=14 [$LINUX]
 			font-style=normal
 			padding-left=0
 			padding-top=0
 			padding-bottom=0
+			padding-right=18
 
 			render_bg {
-				0="image(x1+3,y0+2,x1+17,y1, graphics/news)"
+				0="image(x1-15,y0+2,x1-1,y1, graphics/news)"
 			}
 		}
-
 			links:hover {
 				textcolor="lightestBlue"
 				font-family=basefont
 				font-size=15
-				font-size=14 [$LINUX]
+font-size=14 [$LINUX]
 				font-style=normal
 			}
 			links:disabled {
 				textcolor="grey"
 			}
+
 		label {
 			font-size=15
-			font-size=14 [$LINUX]
+font-size=14 [$LINUX]
 		}
+
 		// For the "Auto-Updates Enabled"
 		settingslink {
 			textcolor="blue"
 			font-family=basefont
 			font-size=15
-			font-size=14 [$LINUX]
-			font-style=regular
-			render_bg {
-				0="image(x1+3, y0+3, x1+17, y1, graphics/auto_downloads)"
-			}
-		}
-		settingslink:hover {
-			textcolor="lightestBlue"
-			font-family=basefont
-			font-size=15
-			font-size=14 [$LINUX]
+font-size=14 [$LINUX]
 			font-style=regular
 			padding-left=0
 			padding-top=0
 			padding-bottom=0
+			padding-right=18
+			render_bg {
+				0="image(x1-15, y0+3, x1-1, y1, graphics/auto_downloads)"
+			}
 		}
-		settingslink:disabled {
-			textcolor="grey50"
-		}
+			settingslink:hover {
+				textcolor="lightestBlue"
+				font-family=basefont
+				font-size=15
+	font-size=14 [$LINUX]
+				font-style=regular
+			}
+			settingslink:disabled {
+				textcolor="grey50"
+			}
+
 		rightcolumnlink:hover {
 			textcolor=none
 		}
+
 		// The "Downloaded" label
 		label2 {
 			bgcolor=none
 			textcolor="lightestGrey"
 			font-size=15
-			font-size=14 [$LINUX]
+font-size=14 [$LINUX]
 			font-style="regular"
 		}
-		// The "Paused" label
+
 		label3 {
 			bgcolor=none
-			textcolor="lightestGrey"
+			textcolor=blue
 			font-size=15
-			font-size=14 [$LINUX]
-			font-style="regular"
+font-size=14 [$LINUX]
+			font-style="uppercase italic"
 		}
+
 		// Name of the game/app
 		ModuleHeading {
 			bgcolor="none"
@@ -102,23 +111,29 @@
 			font-outerglow-offset=1
 			font-style="outerglow"
 		}
+
 		// Contains the "Update Required" text.
 		ModuleHeading2 {
 			bgcolor="none"
 			textcolor="orange"
 			font-family=basefont
-			font-size="15"
+			font-size=16
+font-size=15 [$LINUX]
+			font-weight=600
 		}
+
 		// Doesn't seem to be used for anything?
 		panelBgColorActive {
 			bgcolor=none
 		}
+
 		gameImagePanel {
 			inset="0 0 0 0"
 			render {
 				0="image(x0,y0+3,x1,y1, graphics/download_overlay)"
 			}
 		}
+
 		gameImagePanelHighlight {
 			bgcolor=none
 			inset="0 0 0 0"
@@ -176,84 +191,85 @@
 				22="fill(x1-1,y1-3,x1,y1-2, greenButtonDarkenedCorners)"
 			}
 		}
-		DetailsLaunchButton:Hover {
-			render_bg {
-					// Background
-					-2="gradient(x1-1,y0+2,x1,y1-2,greenButtonHoverGradientStart, greenButtonHoverGradientEnd)"
-					-1="gradient(x0,y0+2,x0+1,y1-2,greenButtonHoverGradientStart, greenButtonGradientEnd)"
-					0="gradient(x0+1,y0+1,x1-1,y1-1,greenButtonHoverGradientStart, greenButtonHoverGradientEnd)"
+			DetailsLaunchButton:Hover {
+				render_bg {
+						// Background
+						-2="gradient(x1-1,y0+2,x1,y1-2,greenButtonHoverGradientStart, greenButtonHoverGradientEnd)"
+						-1="gradient(x0,y0+2,x0+1,y1-2,greenButtonHoverGradientStart, greenButtonGradientEnd)"
+						0="gradient(x0+1,y0+1,x1-1,y1-1,greenButtonHoverGradientStart, greenButtonHoverGradientEnd)"
 
 
-					1="fill(x0+2,y1-1,x1-2,y1, greenButtonHoverGradientEnd)"
+						1="fill(x0+2,y1-1,x1-2,y1, greenButtonHoverGradientEnd)"
 
-					//Anti-Alias
-					2="fill(x0+1,y0,x0+2,y0+1, greenButtonHoverAntiAliasedCorners)" // Top Left
-					3="fill(x0,y0+1,x0+1,y0+2, greenButtonHoverAntiAliasedCorners)" // Top Left
-					4="fill(x1-2, y0, x1-1, y0+1, greenButtonHoverDarkenedCorners)" // Top Right
-					5="fill(x1-1,y0+1,x1,y0+2, greenButtonHoverDarkenedCorners)" // Top Right
-					6="fill(x0, y1-2, x0+1, y1-1, greenButtonHoverAntiAliasedCorners)" // Bottom Left
-					7="fill(x0+1, y1-1, x0+2, y1, greenButtonHoverAntiAliasedCorners)" // Bottom Left
-					8="fill(x1-2, y1-1, x1-1, y1, greenButtonHoverAntiAliasedCorners)" // Bottom Right
-					9="fill(x1-1, y1-2, x1, y1-1, greenButtonHoverAntiAliasedCorners)" // Bottom Right
+						//Anti-Alias
+						2="fill(x0+1,y0,x0+2,y0+1, greenButtonHoverAntiAliasedCorners)" // Top Left
+						3="fill(x0,y0+1,x0+1,y0+2, greenButtonHoverAntiAliasedCorners)" // Top Left
+						4="fill(x1-2, y0, x1-1, y0+1, greenButtonHoverDarkenedCorners)" // Top Right
+						5="fill(x1-1,y0+1,x1,y0+2, greenButtonHoverDarkenedCorners)" // Top Right
+						6="fill(x0, y1-2, x0+1, y1-1, greenButtonHoverAntiAliasedCorners)" // Bottom Left
+						7="fill(x0+1, y1-1, x0+2, y1, greenButtonHoverAntiAliasedCorners)" // Bottom Left
+						8="fill(x1-2, y1-1, x1-1, y1, greenButtonHoverAntiAliasedCorners)" // Bottom Right
+						9="fill(x1-1, y1-2, x1, y1-1, greenButtonHoverAntiAliasedCorners)" // Bottom Right
 
-					// 1px Solid Line Top
-					10="fill(x0+3, y0, x1-3, y0+1, greenButtonHoverHighlight)" // Main Line
-					11="fill(x0+2, y0, x0+3, y0+1, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
-					12="fill(x0+1, y0+1, x0+2, y0+2, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
-					13="fill(x0, y0+2, x0+1, y0+3, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
-					14="fill(x1-3, y0, x1-2, y0+1, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
-					15="fill(x1-2, y0+1, x1-1, y0+2, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
-					16="fill(x1-1, y0+2, x1, y0+3, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
+						// 1px Solid Line Top
+						10="fill(x0+3, y0, x1-3, y0+1, greenButtonHoverHighlight)" // Main Line
+						11="fill(x0+2, y0, x0+3, y0+1, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
+						12="fill(x0+1, y0+1, x0+2, y0+2, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
+						13="fill(x0, y0+2, x0+1, y0+3, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
+						14="fill(x1-3, y0, x1-2, y0+1, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
+						15="fill(x1-2, y0+1, x1-1, y0+2, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
+						16="fill(x1-1, y0+2, x1, y0+3, greenButtonHoverHighlightAntiAliasing)" // Anti-Aliasing
 
-					// Bottom Corner Rounding
-					17="fill(x0,y1-3,x0+1,y1-2, greenButtonHoverDarkenedCorners)"
-					18="fill(x0+1,y1-2,x0+2,y1-1, greenButtonHoverDarkenedCorners)"
-					19="fill(x0+2,y1-1,x0+3,y1, greenButtonHoverDarkenedCorners)"
+						// Bottom Corner Rounding
+						17="fill(x0,y1-3,x0+1,y1-2, greenButtonHoverDarkenedCorners)"
+						18="fill(x0+1,y1-2,x0+2,y1-1, greenButtonHoverDarkenedCorners)"
+						19="fill(x0+2,y1-1,x0+3,y1, greenButtonHoverDarkenedCorners)"
 
-					20="fill(x1-3,y1-1,x1-2,y1, greenButtonHoverDarkenedCorners)"
-					21="fill(x1-2,y1-2,x1-1,y1-1, greenButtonHoverDarkenedCorners)"
-					22="fill(x1-1,y1-3,x1,y1-2, greenButtonHoverDarkenedCorners)"
+						20="fill(x1-3,y1-1,x1-2,y1, greenButtonHoverDarkenedCorners)"
+						21="fill(x1-2,y1-2,x1-1,y1-1, greenButtonHoverDarkenedCorners)"
+						22="fill(x1-1,y1-3,x1,y1-2, greenButtonHoverDarkenedCorners)"
+				}
 			}
-		}
-		DetailsLaunchButton:Active {
-			render_bg {
-					// Background
-					-2="gradient(x1-1,y0+2,x1,y1-2,greenButtonActiveGradientStart, greenButtonActiveGradientEnd)"
-					-1="gradient(x0,y0+2,x0+1,y1-2,greenButtonActiveGradientStart, greenButtonGradientEnd)"
-					0="gradient(x0+1,y0+1,x1-1,y1-1,greenButtonActiveGradientStart, greenButtonActiveGradientEnd)"
+			DetailsLaunchButton:Active {
+				render_bg {
+						// Background
+						-2="gradient(x1-1,y0+2,x1,y1-2,greenButtonActiveGradientStart, greenButtonActiveGradientEnd)"
+						-1="gradient(x0,y0+2,x0+1,y1-2,greenButtonActiveGradientStart, greenButtonGradientEnd)"
+						0="gradient(x0+1,y0+1,x1-1,y1-1,greenButtonActiveGradientStart, greenButtonActiveGradientEnd)"
 
 
-					1="fill(x0+2,y1-1,x1-2,y1, greenButtonActiveGradientEnd)"
+						1="fill(x0+2,y1-1,x1-2,y1, greenButtonActiveGradientEnd)"
 
-					//Anti-Alias
-					2="fill(x0+1,y0,x0+2,y0+1, greenButtonActiveAntiAliasedCorners)" // Top Left
-					3="fill(x0,y0+1,x0+1,y0+2, greenButtonActiveAntiAliasedCorners)" // Top Left
-					4="fill(x1-2, y0, x1-1, y0+1, greenButtonActiveDarkenedCorners)" // Top Right
-					5="fill(x1-1,y0+1,x1,y0+2, greenButtonActiveDarkenedCorners)" // Top Right
-					6="fill(x0, y1-2, x0+1, y1-1, greenButtonActiveAntiAliasedCorners)" // Bottom Left
-					7="fill(x0+1, y1-1, x0+2, y1, greenButtonActiveAntiAliasedCorners)" // Bottom Left
-					8="fill(x1-2, y1-1, x1-1, y1, greenButtonActiveAntiAliasedCorners)" // Bottom Right
-					9="fill(x1-1, y1-2, x1, y1-1, greenButtonActiveAntiAliasedCorners)" // Bottom Right
+						//Anti-Alias
+						2="fill(x0+1,y0,x0+2,y0+1, greenButtonActiveAntiAliasedCorners)" // Top Left
+						3="fill(x0,y0+1,x0+1,y0+2, greenButtonActiveAntiAliasedCorners)" // Top Left
+						4="fill(x1-2, y0, x1-1, y0+1, greenButtonActiveDarkenedCorners)" // Top Right
+						5="fill(x1-1,y0+1,x1,y0+2, greenButtonActiveDarkenedCorners)" // Top Right
+						6="fill(x0, y1-2, x0+1, y1-1, greenButtonActiveAntiAliasedCorners)" // Bottom Left
+						7="fill(x0+1, y1-1, x0+2, y1, greenButtonActiveAntiAliasedCorners)" // Bottom Left
+						8="fill(x1-2, y1-1, x1-1, y1, greenButtonActiveAntiAliasedCorners)" // Bottom Right
+						9="fill(x1-1, y1-2, x1, y1-1, greenButtonActiveAntiAliasedCorners)" // Bottom Right
 
-					// 1px Solid Line Top
-					10="fill(x0+3, y0, x1-3, y0+1, greenButtonActiveHighlight)" // Main Line
-					11="fill(x0+2, y0, x0+3, y0+1, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
-					12="fill(x0+1, y0+1, x0+2, y0+2, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
-					13="fill(x0, y0+2, x0+1, y0+3, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
-					14="fill(x1-3, y0, x1-2, y0+1, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
-					15="fill(x1-2, y0+1, x1-1, y0+2, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
-					16="fill(x1-1, y0+2, x1, y0+3, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
+						// 1px Solid Line Top
+						10="fill(x0+3, y0, x1-3, y0+1, greenButtonActiveHighlight)" // Main Line
+						11="fill(x0+2, y0, x0+3, y0+1, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
+						12="fill(x0+1, y0+1, x0+2, y0+2, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
+						13="fill(x0, y0+2, x0+1, y0+3, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
+						14="fill(x1-3, y0, x1-2, y0+1, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
+						15="fill(x1-2, y0+1, x1-1, y0+2, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
+						16="fill(x1-1, y0+2, x1, y0+3, greenButtonActiveHighlightAntiAliasing)" // Anti-Aliasing
 
-					// Bottom Corner Rounding
-					17="fill(x0,y1-3,x0+1,y1-2, greenButtonActiveDarkenedCorners)"
-					18="fill(x0+1,y1-2,x0+2,y1-1, greenButtonActiveDarkenedCorners)"
-					19="fill(x0+2,y1-1,x0+3,y1, greenButtonActiveDarkenedCorners)"
+						// Bottom Corner Rounding
+						17="fill(x0,y1-3,x0+1,y1-2, greenButtonActiveDarkenedCorners)"
+						18="fill(x0+1,y1-2,x0+2,y1-1, greenButtonActiveDarkenedCorners)"
+						19="fill(x0+2,y1-1,x0+3,y1, greenButtonActiveDarkenedCorners)"
 
-					20="fill(x1-3,y1-1,x1-2,y1, greenButtonActiveDarkenedCorners)"
-					21="fill(x1-2,y1-2,x1-1,y1-1, greenButtonActiveDarkenedCorners)"
-					22="fill(x1-1,y1-3,x1,y1-2, greenButtonActiveDarkenedCorners)"
+						20="fill(x1-3,y1-1,x1-2,y1, greenButtonActiveDarkenedCorners)"
+						21="fill(x1-2,y1-2,x1-1,y1-1, greenButtonActiveDarkenedCorners)"
+						22="fill(x1-1,y1-3,x1,y1-2, greenButtonActiveDarkenedCorners)"
+				}
 			}
-		}
+
 		topOfQueueButton {
 			render {
 				1="image( x0+4, y0+5, x1, y1, graphics/move_top )"
@@ -274,6 +290,7 @@
 			}
 		}
 	}
+
 	layout {
 		region {
 			name="bottom"
@@ -282,21 +299,25 @@
 			width="max"
 			height=6
 		}
+
 		region {
 			name="column1"
 			x=11
 		}
+
 		region {
 			name="column2"
 			x=210
 			width=max
 		}
+
 		region {
 			name="column4"
 			x=700
 			width=max
 			overflow=allow-horizontal
 		}
+
 		place {
 			control="downloadprogressbar"
 			region=bottom
@@ -306,6 +327,7 @@
 			margin-right=16
 			dir=right
 		}
+
 		// left-mid column
 		place {
 			control="namelabel"
@@ -313,6 +335,7 @@
 			x=5
 			y=5
 		}
+
 		place {
 			control="gameimage"
 			region="column1"
@@ -323,53 +346,61 @@
 			height=85
 			dir=down
 		}
+
 		place {
 			control="updatetypelabel"
 			region="column2"
 			align=left
 			x=-5
-			y=44
+			y=43			//line 1
 		}
+
 		place {
 			control="downloadtotallabel,downloadtotalfield"
 			region="column2"
 			align=left
-			y=60
-			spacing=4
-		}
-		place {
-			control="starttimelabel,starttimefield"
-			region="column2"
-			align=left
 			x=0
-			y=76
-			dir="right"
+			margin-top=60	//line 2
 			spacing=4
 		}
+
 		place {
 			control="timecompletedlabel,timecompletedfield"
 			region="column2"
 			align=left
 			x=0
-			margin-top=71
+			margin-top=75	//line 3
 			spacing=4
 		}
+
 		place {
 			control="pausereasonlabel,pausereasonfield"
 			region="column2"
 			align=left
 			x=0
-			y=76
+			margin-top=75	//line 3
 			spacing=4
 		}
+
+		place {
+			control="starttimelabel,starttimefield"
+			region="column2"
+			align=left
+			x=0
+			margin-top=75	//line 3
+			dir="right"
+			spacing=4
+		}
+
 		place {
 			control="timeremaininglabel,timeremainingfield"
 			region="column2"
 			align=left
 			x=0
-			y=92
+			margin-top=90	//line 4
 			spacing=4
 		}
+
 		place {
 			control="launchbutton,topofqueuebutton,removefromqueuebutton"
 			region="column4"
@@ -381,22 +412,25 @@
 			dir=right
 			spacing=10
 		}
+
 		place {
 			control="newslink"
 			region="column4"
 			align=right
-			margin-top=73
-			margin-right=34
+			margin-top=75	//line 3
+			margin-right=16
 			spacing=10
 		}
+
 		place {
 			control="settingslink"
 			region=column4
 			align=right
-			margin-top=89
-			margin-right=34
+			margin-top=90	//line 4
+			margin-right=16
 			dir=right
 		}
+
 		place {
 			control="workshopbanner"
 			width=0

--- a/resource/layout/appdownloadpanel.layout
+++ b/resource/layout/appdownloadpanel.layout
@@ -92,7 +92,7 @@ font-size=14 [$LINUX]
 			font-style="regular"
 		}
 
-		label3 {
+		label3 {	//this looks really awkward no matter what you do, because Valve made the strings that use it all lowercase
 			bgcolor=none
 			textcolor=blue
 			font-size=15

--- a/resource/layout/downloadsummarypanel.layout
+++ b/resource/layout/downloadsummarypanel.layout
@@ -9,11 +9,12 @@
 			bgcolor=darkestgrey
 			inset="0 0 0 0"
 	  	}
+
 		throttleLabel {
-			bgcolor	   none
-			font-size   "13"
-			textcolor   "white"
-			padding-top	"0"
+			bgcolor=none
+			font-size="13"
+			textcolor="white"
+			padding-top="0"
 			font-style="outerglow,regular"
 			font-outerglow-color="darkestGrey"
 			font-outerglow-offset=1
@@ -21,10 +22,10 @@
 	    }
 
 		throttleValue {
-			bgcolor	   none
-			font-size   "13"
-			textcolor   "orange"
-			padding-top	"0"
+			bgcolor=none
+			font-size="13"
+			textcolor="orange"
+			padding-top="0"
 			font-style="outerglow,uppercase"
 			font-outerglow-color="darkestGrey"
 			font-outerglow-offset=2
@@ -36,38 +37,37 @@
 	   	}
 
 		bigtext {
-		 font-family=basefont
-		 font-size=18
-		 font-style="outerglow,regular"
-		 font-outerglow-color="darkestGrey"
-		 font-outerglow-offset=1
-		 font-outerglow-filtersize=4
-		 font-weight=700
-		 textcolor="white"
-
+			font-family=basefont
+			font-size=18
+			font-style="outerglow,regular"
+			font-outerglow-color="darkestGrey"
+			font-outerglow-offset=1
+			font-outerglow-filtersize=4
+			font-weight=700
+			textcolor="white"
 		}
+
 		bigtextlabel {
-		 font-family=basefont
-		 font-size=18
-		 font-style="outerglow,regular"
-		 font-outerglow-color="darkestGrey"
-		 font-outerglow-offset=1
-		 font-outerglow-filtersize=4
-		 textcolor="lightestGrey"
+			font-family=basefont
+			font-size=18
+			font-style="outerglow,regular"
+			font-outerglow-color="darkestGrey"
+			font-outerglow-offset=1
+			font-outerglow-filtersize=4
+			textcolor="lightestGrey"
 		}
 
 		bigtextHeader {
-		 font-family=basefont
-		 font-size=18
-		 textcolor="red"
+			font-family=basefont
+			font-size=18
+			textcolor="red"
 		}
 
-
 		bigTextNumbers {
-		 font-family=basefont
-		 font-size="17"
-		 textcolor="green"
-		 font-style="regular"
+			font-family=basefont
+			font-size="17"
+			textcolor="green"
+			font-style="regular"
 		}
 
 		PauseButton [$OSX] {
@@ -129,7 +129,6 @@
 				23="gradient(x0+1,y1,x1-1,y1+4, black40, none)"
 			}
 		}
-
 		PauseButton [!$OSX] {
 			inset="25 3 0 0"
 			font-family=headerfont
@@ -189,7 +188,6 @@
 				23="gradient(x0+1,y1,x1-1,y1+4, black40, none)"
 			}
 		}
-
 			PauseButton:Hover {
 				render_bg {
 					// Background
@@ -231,7 +229,6 @@
 					23="gradient(x0+1,y1,x1-1,y1+4, black40, none)"
 				}
 			}
-
 			PauseButton:Selected {
 				render_bg {
 					// Background
@@ -273,8 +270,6 @@
 					23="gradient(x0+1,y1,x1-1,y1+4, black40, none)"
 				}
 			}
-
-
 			PauseButton:Active {
 				render_bg {
 					// Background
@@ -375,7 +370,6 @@
 				23="gradient(x0+1,y1,x1-1,y1+4, black40, none)"
 			}
 		}
-
 		ResumeButton [!$OSX]{
 			inset="25 3 0 0"
 			font-family=headerfont
@@ -434,7 +428,6 @@
 				23="gradient(x0+1,y1,x1-1,y1+4, black40, none)"
 			}
 		}
-
 			ResumeButton:Hover {
 				render_bg {
 					// Background
@@ -476,7 +469,6 @@
 					23="gradient(x0+1,y1,x1-1,y1+4, black40, none)"
 				}
 			}
-
 			ResumeButton:Selected {
 				render_bg {
 					// Background
@@ -518,8 +510,6 @@
 					23="gradient(x0+1,y1,x1-1,y1+4, black40, none)"
 				}
 			}
-
-
 			ResumeButton:Active {
 				render_bg {
 					// Background
@@ -561,6 +551,7 @@
 					23="gradient(x0+1,y1,x1-1,y1+4, black40, none)"
 				}
 			}
+
 		infoGraphic {
 			bgcolor   "none"
 			textcolor "green"
@@ -584,6 +575,7 @@
 			height=500
 			margin-top=0
 		}
+		
 		//Universal Pause/Resume Button
 		place {
 			control="pauseresumeallbutton"
@@ -601,56 +593,39 @@
 			height=0
 			width=0
 		}
+		
 		place {
-			control="download_rate_value"
+			control="download_rate_value,download_rate"
 			x=12
-			spacing=8
+			spacing=3
 			height=30
 			y=16
 		}
 
 		place {
-			control="download_rate"
-			start="download_rate_value"
-			x=3
-			height=30
-		}
-		place {
-			control="peak_download_rate_value"
+			control="peak_download_rate_value,peak_download_rate"
 			x=12
-			spacing=8
+			spacing=3
 			height=30
 			y=46
 		}
 
 		place {
-			control="peak_download_rate"
-			start="peak_download_rate_value"
-			x=3
-			height=30
-		}
-		place {
-			control="total_downloaded_value"
+			control="total_downloaded_value,total_downloaded"
 			x=12
-			spacing=8
+			spacing=3
 			height=30
 			y=76
 		}
 
-		place {
-			control="total_downloaded"
-			start="total_downloaded_value"
-			x=3
-			height=30
-		}
 		//Disk Usage
 		place {
 			control="disk_status_image,disk_status_label"
-			y=96
+			y=90
 			height=40
 			spacing=8
 			align=right
-			margin-right=16
+			margin-right=12
 		}
 
 		// Blackout/Throttling Values - Right

--- a/resource/layout/ugcdownloadpanel.layout
+++ b/resource/layout/ugcdownloadpanel.layout
@@ -10,12 +10,14 @@
 				2="fill(x0,y0+1,x1,y0+2, grey25)"
 				5="image(x0+11,y0+35,x1,y1, graphics/ugc_download_overlay)"
 			}
+
 			render_bg {
 				1="gradient(x0,y1,x1,y1+6, black40, none)"
 				2="fill(x0,y0,x1,y1, lightGreyEnd)"
 				3="fill(x0,y0,x1,y0+1, greyHighlight)"
 			}
 		}
+
 		panelStyleHighlight {
 			minimum-height=150
 			render {
@@ -25,6 +27,7 @@
 				0="fill(x0,y0,x1,y1+10, black65)"
 			}
 		}
+
 		links {
 			textcolor="blue"
 			font-family=basefont
@@ -34,12 +37,12 @@ font-size=14 [$LINUX]
 			padding-left=0
 			padding-top=0
 			padding-bottom=0
+			padding-right=18
 
 			render_bg {
-				0="image(x1+3,y0+2,x1+17,y1, graphics/news)"
+				0="image(x1-15,y0+2,x1-1,y1, graphics/news)"
 			}
 		}
-
 			links:hover {
 				textcolor="lightestBlue"
 				font-family=basefont
@@ -50,9 +53,11 @@ font-size=14 [$LINUX]
 			links:disabled {
 				textcolor="grey"
 			}
+
 		rightcolumnlink:hover {
 			textcolor=none
 		}
+
 		// The "Downloaded" label
 		label2 {
 			bgcolor=none
@@ -61,6 +66,7 @@ font-size=14 [$LINUX]
 font-size=14 [$LINUX]
 			font-style="regular"
 		}
+
 		// Name of the game/app
 		ModuleHeading {
 			bgcolor="none"
@@ -72,17 +78,22 @@ font-size=14 [$LINUX]
 			font-outerglow-offset=1
 			font-style="outerglow"
 		}
+
 		// Contains the "Update Required" text.
 		ModuleHeading2 {
 			bgcolor="none"
 			textcolor="orange"
 			font-family=basefont
-			font-size="15"
+			font-size=16
+font-size=15 [$LINUX]
+			font-weight=600
 		}
+		
 		// Doesn't seem to be used for anything?
 		panelBgColorActive {
 			bgcolor=none
 		}
+
 		SlimProgressBar {
 			textcolor=green
 			render_bg {
@@ -90,6 +101,7 @@ font-size=14 [$LINUX]
 				1="fill(x0,y1,x1,y1+1, grey25)"
 			}
 		}
+
 		SmRemoveButton {
 			textcolor=none
 			render {
@@ -97,25 +109,13 @@ font-size=14 [$LINUX]
 			}
 		}
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 		graphdownloadrate {
 			font-family=basefont
 			font-size="14"
 			font-style="normal,regular"
 			textcolor=orange
 		}
+
 		SmPauseButton {
 			font-family=basefont
 			font-size=16
@@ -128,6 +128,7 @@ font-size=14 [$LINUX]
 				1="image( x0 + 5, y0 + 4, x1, y1, graphics/pause )"
 			}
 		}
+
 		SmResumeButton {
 			font-family=basefont
 			font-size=16
@@ -143,7 +144,7 @@ font-size=14 [$LINUX]
 
 		ViewModsButton {
 			inset-left=20
-			minimum-width=80
+			minimum-width=64
 			render {
 				1="image( x0 + 8, y0 + 9, x1, y1, graphics/icon_workshop )"
 			}
@@ -158,21 +159,25 @@ font-size=14 [$LINUX]
 			width="max"
 			height=6
 		}
+
 		region {
 			name="column1"
 			x=11
 		}
+
 		region {
 			name="column2"
 			x=210
 			width=max
 		}
+
 		region {
 			name="column4"
 			x=700
 			width=max
 			overflow=allow-horizontal
 		}
+
 		place {
 			control="downloadprogressbar"
 			region=bottom
@@ -182,6 +187,7 @@ font-size=14 [$LINUX]
 			margin-right=16
 			dir=right
 		}
+
 		// left-mid column
 		place {
 			control="namelabel"
@@ -189,6 +195,7 @@ font-size=14 [$LINUX]
 			x=5
 			y=5
 		}
+
 		place {
 			control="gameimage"
 			region="column1"
@@ -199,6 +206,7 @@ font-size=14 [$LINUX]
 			height=85
 			dir=down
 		}
+
 		place {
 			control=workshopminibanner
 			start=gameimage
@@ -214,67 +222,62 @@ font-size=14 [$LINUX]
 			region="column2"
 			align=left
 			x=-5
-			y=44
+			y=43			//line 1
 		}
+
 		place {
 			control="downloadtotallabel,downloadtotalfield"
 			region="column2"
 			align=left
-			y=60
+			margin-top=60	//line 2
 			spacing=4
 		}
+
 		place {
 			control="downloadfileslabel,downloadfilesfield"
 			region="column2"
 			align=left
-			y=76
+			margin-top=75	//line 3
 			spacing=4
 		}
+
 		place {
 			control="starttimelabel,starttimefield"
 			region="column2"
 			align=left
 			x=0
-			y=91
+			margin-top=90	//line 4
 			dir="right"
 			spacing=4
 		}
+
 		place {
 			control="timeremaininglabel,timeremainingfield"
 			region="column2"
 			align=left
 			x=0
-			y=107
+			margin-top=105	//line 5
 			spacing=4
 		}
 
 		place {
-			control="pauseresumebutton"
+			control="viewmodsbutton,pauseresumebutton"
 			region="column4"
+			align=right
 			width=33
 			height=33
-			y=20
+			margin-top=20
 			margin-right=16
-			align=right
-			dir=down
+			dir=right
+			spacing=10
 		}
-		place {
-			control=viewmodsbutton
-			region=column4
-			y=61
-			align=right
-			height=33
-			margin-right=16
-			dir=down
-		}
+
 		place {
 			control="graphdownloadrate"
 			region="column4"
 			align=right
 			margin-right=16
-			y=124
+			y=124			//line 6 + 4px
 		}
-
-
 	}
 }


### PR DESCRIPTION
UGC (workshop) and App downloads now have the same alignment for the
progress text.
Made the download status text larger and bolded.
UGC downloads' "View" button is now level with the close/pause button.
View News/Auto-Download Settings links' icons are now clickable. Each
link also lines up with the progress text to the left of it.

Previews:
https://i.imgur.com/LI2dn5m.png
https://i.imgur.com/MMJUkXM.png