### PR TITLE
Tweaks to DialogGameInfo/AutoRetry

### DIFF
--- a/servers/DialogGameInfo.res
+++ b/servers/DialogGameInfo.res
@@ -39,14 +39,6 @@ font-size=14 [$LINUX]
 			margin-bottom=52
 		}
 
-		region {
-			name=right
-			align=right
-			width=400
-			height=max
-			margin-top=26
-			margin-bottom=52
-		}
 		// Server Name
 		place {
 			control=ServerLabel
@@ -72,8 +64,8 @@ font-size=14 [$LINUX]
 			start=ServerText
 			dir=down
 			spacing=0
-			margin-top=16
 			margin-left=0
+			margin-top=16
 		}
 		// We seperate the value from the header to avoid a weird width-bug that cuts off text
 		place {
@@ -183,9 +175,18 @@ font-size=14 [$LINUX]
 			dir=down
 		}
 
+		region {
+			name=right
+			align=right
+			width=400
+			height=max
+			margin-top=26
+			margin-bottom=52
+		}
+
 		place {
-			region=right
 			control="PlayerList"
+			region=right
 			align=right
 			width=max
 			height=max
@@ -196,9 +197,11 @@ font-size=14 [$LINUX]
 			control="AutoRetryAlert,AutoRetryJoin"
 			region=right
 			start=PlayerList
-			width=max
-			height=24
 			dir=down
+			spacing=6
+			width=max
+			height=20
+			margin-top=7
 		}
 
 		//Bottom

--- a/servers/DialogGameInfo_AutoRetry.res
+++ b/servers/DialogGameInfo_AutoRetry.res
@@ -2,7 +2,7 @@
 	styles {
 		CDialogGameInfo {
 			minimum-width=620
-			minimum-height=467	//this seems to be ignored
+			minimum-height=477	//this seems to be ignored
 		}
 
 		LabelDull {
@@ -41,8 +41,8 @@ font-size=14 [$LINUX]
 
 		// Server Name
 		place {
-			region=left
 			control=ServerLabel
+			region=left
 			margin-left=0
 			dir=down
 			spacing=0
@@ -62,10 +62,10 @@ font-size=14 [$LINUX]
 			control=ServerIPLabel
 			region=left
 			start=ServerText
-			margin-left=0
-			margin-top=16
 			dir=down
 			spacing=0
+			margin-left=0
+			margin-top=16
 		}
 		// We seperate the value from the header to avoid a weird width-bug that cuts off text
 		place {
@@ -73,8 +73,8 @@ font-size=14 [$LINUX]
 			region=left
 			start=ServerIPLabel
 			width=max
-			margin-top=-8
 			margin-left=-2
+			margin-top=-8
 			dir=down
 		}
 		// GAME
@@ -118,8 +118,8 @@ font-size=14 [$LINUX]
 
 		// PLAYERS
 		place {
-			region=left
 			control=PlayersLabel
+			region=left
 			start=MapText
 			margin-left=0
 			margin-top=16
@@ -128,8 +128,8 @@ font-size=14 [$LINUX]
 		}
 		// We seperate the value from the header to avoid a weird width-bug that cuts off text
 		place {
-			region=left
 			control=PlayersText
+			region=left
 			start=PlayersLabel
 			width=max
 			margin-top=-4
@@ -137,8 +137,8 @@ font-size=14 [$LINUX]
 		}
 		// VAC
 		place {
-			region=left
 			control=Label1
+			region=left
 			start=PlayersText
 			margin-left=0
 			margin-top=16
@@ -190,18 +190,18 @@ font-size=14 [$LINUX]
 			align=right
 			width=max
 			height=max
-			margin-bottom=53
+			margin-bottom=63
 		}
 
 		place {
 			control="AutoRetryAlert,AutoRetryJoin"
 			region=right
 			start=PlayerList
-			margin-top=3
-			spacing=3
+			dir=down
+			spacing=6
 			width=max
 			height=20
-			dir=down
+			margin-top=7
 		}
 
 		//Bottom


### PR DESCRIPTION
Valve made the window automatically +y60px when the Auto-Retry button is
clicked, while we had it doing +y50px, which meant the elements would
move a bit when the button was toggled (where they should have stayed
effectively still).
