### PR TITLE
Fixes for FileOpenDialog

### DIFF
--- a/resource/FileOpenDialog.res
+++ b/resource/FileOpenDialog.res
@@ -1,0 +1,13 @@
+"resource/FileOpenDialog.res" {
+	styles {
+		ListPanelInterior {
+			inset="2 0 0 0"
+		}
+		ComboBox {
+			minimum-height="22"
+		}
+		Button {
+			inset="-4 0 0 0"
+		}
+	}
+}


### PR DESCRIPTION
Pushes the list panel to the right by 2px
Made the url box 2px smaller to fit inline with buttons
Fixed the positioning of the two buttons at the top but sacrificing the inset of the two buttons at the bottom.

I dunno if i'm having a blank but I couldn't find a way to style the buttons individually, only all at once. It might be better to make the images themselves smaller ?

re: #393 